### PR TITLE
Wrap batch account locking with a parent mutex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Development
+  - Wrap batch account locking with a parent mutex
+
 # Version 1.0.0
   - Mainnet release
 

--- a/services/locker/service.go
+++ b/services/locker/service.go
@@ -15,7 +15,16 @@ package locker
 
 // Service provides the features and functions for a global account locker.
 type Service interface {
+	// PreLock must be called prior to locking one or more public keys.
+	// It obtains a locker-wide mutex, to ensure that only one goroutine
+	// can be locking or unlocking groups of public keys at a time.
+	PreLock()
+	// PostLock must be called after locking one or more public keys.
+	// It frees the locker-wide mutex obtained by PreLock().
+	PostLock()
 	// Lock acquires a lock for a given public key.
+	// If more than one lock is being acquired in a batch, ensure that
+	// PreLock() is called beforehand and PostLock() afterwards.
 	Lock(key [48]byte)
 	// Unlock frees a lock for a given public key.
 	Unlock(key [48]byte)


### PR DESCRIPTION
Dirk's internal rules system only allows a single request against a given public key at a time.  However, with the introduction of the
`SignBeaconAttestations` RPC call it is possible for multiple keys to be attached to a single call.

In the situation where there are multiple clients simultaneously calling `SignBeaconAttestations` it is possible for client 1 to request for keys [a,b] and client 2 to request for keys [b,a], and this creates a situation where a deadlock is possible.

This change avoids this situation by only allowing a single call across all active requests to lock keys at a time, ensuring that even if keys are presented out of order with multiple simultaneous calls a potential deadlock situation is avoided.