### PR TITLE
Copy slashing protection values on fetch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Development
+  - Explicitly close database on shutdown, with delay to allow completion
   - Wrap batch account locking with a parent mutex
 
 # Version 1.0.0

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	// #nosec G108
 	_ "net/http/pprof"
@@ -161,6 +162,8 @@ func main() {
 
 	log.Info().Msg("Stopping dirk")
 	readyMonitor.Ready(false)
+	// Give services a chance to stop cleanly before we exit.
+	time.Sleep(2 * time.Second)
 }
 
 // fetchConfig fetches configuration from various sources.

--- a/rules/standard/service.go
+++ b/rules/standard/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -48,10 +48,22 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		return nil, err
 	}
 
-	return &Service{
+	s := &Service{
 		store:    store,
 		adminIPs: parameters.adminIPs,
-	}, nil
+	}
+
+	// Close the store when the context is cancelled.
+	go func() {
+		<-ctx.Done()
+		if err := s.Close(ctx); err != nil {
+			log.Error().Err(err).Msg("Failed to cleanly close rules storage")
+		} else {
+			log.Info().Msg("Closed rules storage")
+		}
+	}()
+
+	return s, nil
 }
 
 // Close closes the database for the persistent rules information.

--- a/rules/standard/storage.go
+++ b/rules/standard/storage.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 Attestant Limited.
+// Copyright © 2020, 2021 Attestant Limited.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -56,7 +56,9 @@ func (s *Store) FetchAll(ctx context.Context) (map[[49]byte][]byte, error) {
 			err := item.Value(func(v []byte) error {
 				var key [49]byte
 				copy(key[:], item.Key())
-				items[key] = v
+				value := make([]byte, len(v))
+				copy(value, v)
+				items[key] = value
 				return nil
 			})
 			if err != nil {
@@ -89,7 +91,8 @@ func (s *Store) Fetch(ctx context.Context, key []byte) ([]byte, error) {
 			}
 		}
 		err = item.Value(func(val []byte) error {
-			value = val
+			value = make([]byte, len(val))
+			copy(value, val)
 			return nil
 		})
 		if err != nil {


### PR DESCRIPTION
Copy all values obtained from the slashing protection database as they are returned.  This avoids a potential overwrite situation when bulk fetching information, most notably when data is obtained for generating a slashing protection export.

This fixes an issue where --export-slashing-protection would sometimes provide erroneous information.

This change also explicitly closes the slashing protection database on exit, and holds the main goroutine open for a couple of seconds to ensure the close completes before shutting down Dirk.  A log message is provided stating that the close succeeded (or not).