### PR TITLE
Update storage path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Development
+  - Do not ignore `storage-path` configuration value
+  - Move `server.storage-path` to `storage-path`
   - Explicitly close database on shutdown, with delay to allow completion
   - Wrap batch account locking with a parent mutex
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,8 +28,6 @@ server:
   # listen-address is the interface and port on which Dirk will listen for requests; change `127.0.0.1`
   # to `0.0.0.0` to listen on all network interfaces.
   listen-address: 127.0.0.1:13141
-  # storage-path is the path where information created by the slashing protection system is stored.
-  storage-path: /home/me/dirk/protection
 certificates:
   # server-cert is the majordomo URL to the server's certificate.
   server-cert: file:///home/me/dirk/security/certificates/myserver.example.com.crt
@@ -38,6 +36,9 @@ certificates:
   # ca-cert is the certificate of the CA that issued the client certificates.  If not present Dirk will use
   # the standard CA certificates supplied with the server.
   ca-cert: file:///home/me/dirk/security/certificates/ca.crt
+# storage-path is the path where information created by the slashing protection system is stored.  If not
+# supplied it will default to using the 'storage' directory in the user's home directory.
+storage-path: /home/me/dirk/protection
 # stores is a list of locations and types of Ethereum 2 stores.  If no stores are supplied Dirk will use the
 # default filesystem store.
 stores:

--- a/docs/distributed_key_generation.md
+++ b/docs/distributed_key_generation.md
@@ -97,11 +97,11 @@ server:
   id: 1
   name: `hostname`-1
   listen-address: 0.0.0.0:8881
-  storage-path: ${HOME}/dirk-multi/1/storage
 certificates:
   ca-cert: file://${HOME}/dirk-multi/1/security/ca.crt
   server-cert: file://${HOME}/dirk-multi/1/security/`hostname`-1.crt
   server-key: file://${HOME}/dirk-multi/1/security/`hostname`-1.key
+storage-path: ${HOME}/dirk-multi/1/storage
 stores:
 - name: Local
   type: filesystem
@@ -127,11 +127,11 @@ server:
   id: 2
   name: `hostname`-2
   listen-address: 0.0.0.0:8882
-  storage-path: ${HOME}/dirk-multi/2/storage
 certificates:
   ca-cert: file://${HOME}/dirk-multi/2/security/ca.crt
   server-cert: file://${HOME}/dirk-multi/2/security/`hostname`-2.crt
   server-key: file://${HOME}/dirk-multi/2/security/`hostname`-2.key
+storage-path: ${HOME}/dirk-multi/2/storage
 stores:
 - name: Local
   type: filesystem
@@ -157,11 +157,11 @@ server:
   id: 3
   name: `hostname`-3
   listen-address: 0.0.0.0:8883
-  storage-path: ${HOME}/dirk-multi/3/storage
 certificates:
   ca-cert: file://${HOME}/dirk-multi/3/security/ca.crt
   server-cert: file://${HOME}/dirk-multi/3/security/`hostname`-3.crt
   server-key: file://${HOME}/dirk-multi/3/security/`hostname`-3.key
+storage-path: ${HOME}/dirk-multi/3/storage
 stores:
 - name: Local
   type: filesystem

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func fetchConfig() error {
 	viper.AutomaticEnv()
 
 	// Defaults.
-	viper.Set("server.storage-path", "storage")
+	viper.SetDefault("storage-path", "storage")
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
@@ -586,7 +586,7 @@ func logModules() {
 func initRules(ctx context.Context) (rules.Service, error) {
 	return standardrules.New(ctx,
 		standardrules.WithLogLevel(logLevel(viper.GetString("log-levels.rules"))),
-		standardrules.WithStoragePath(resolvePath(viper.GetString("server.storage-path"))),
+		standardrules.WithStoragePath(resolvePath(viper.GetString("storage-path"))),
 		standardrules.WithAdminIPs(viper.GetStringSlice("server.rules.admin-ips")),
 	)
 }

--- a/slashingprotection.go
+++ b/slashingprotection.go
@@ -256,5 +256,5 @@ func storeSlashingProtection(ctx context.Context, protection *SlashingProtection
 		return errors.Wrap(err, "failed to obtain slashing protection")
 	}
 
-	return errors.New("not implemented")
+	return nil
 }


### PR DESCRIPTION
This change makes Dirk pay attention to user-supplied values for the variable `server.storage-path`, which was ignored previously.

Due to the fact that this fix could cause an issue with slashing protection, where slashing protection was previousl written to one
location and with this fix is now written to another, the configuration value has also moved from `server.storage-path` to just `storage-path`.  This means that slashing protection will continue to work as expected with this change, and still allow users to change their storage path if desired.