### PR TITLE
Garbage collect rules db on startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Development
+  - garbage collect the slashing database on startup to reduce on-disk size
   - provide release metric in `dirk_release`
 
 # Version 1.0.4

--- a/rules/standard/storage.go
+++ b/rules/standard/storage.go
@@ -40,6 +40,17 @@ func NewStore(base string) (*Store, error) {
 		return nil, err
 	}
 
+	// Garbage collect in the background on start.
+	go func(db *badger.DB) {
+		for {
+			log.Trace().Msg("Running garbage collection")
+			if err = db.RunValueLogGC(0.7); err != nil {
+				// Error occurs when there is nothing left to collect.
+				break
+			}
+		}
+	}(db)
+
 	return &Store{
 		db: db,
 	}, nil


### PR DESCRIPTION
The rules DB uses a badger database that increases in size thanks to a log-based writer.  This patch garbage collects the database on startup to keep its size down.