### PR TITLE
Use hierarchical log levels in configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - provide release metric in `dirk_release`
   - use internal account cache for both positive and negative caching
   - run signing rules in parallel, increasing responsiveness for large requests
+  - use hierarchical log levels in configuration; details in the configuration docs
 
 # Version 1.0.4
   - Update dependencies

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,11 +15,6 @@ A sample configuration file in YAML with all current options is shown below:
 log-file: /home/me/dirk.log
 # log-level is the global log level for Dirk logging.
 log-level: Debug
-# log-levels contain override log levels for individual modules.  A full list of modules is supplied later
-# in this document.
-log-levels:
-  signer: Trace
-  accountmanager: None
 server:
   # id should be randomly chosen 8-digit numeric ID; it must be unique across all of your Dirk instances.
   id: 75843236
@@ -115,4 +110,4 @@ Modules levels are used for each module, overriding the global log level.  The a
   - **unlocker** unlocks locked accounts using supplied passphrases
   - **walletmanager** operations on accounts such as locking and unlocking existing wallets
 
-This can be configured using the environment variables `DIRK_LOG_LEVELS_<MODULE>` or the configuration option `log-levels.<module>`.  For example, the peers module logging could be configured using the environment variable `DIRK_LOG_LEVELS_PEERS` or the configuration option `log-levels.peers`.
+This can be configured using the environment variables `DIRK_<MODULE>_LOG_LEVEL` or the configuration option `<module>.log-level`.  For example, the peers module logging could be configured using the environment variable `DIRK_PEERS_LOG_LEVEL` or the configuration option `peers.log-level`.  Log levels are hierarchical, allowing for fine-grained control of logging.

--- a/logging.go
+++ b/logging.go
@@ -15,8 +15,8 @@ package main
 
 import (
 	"os"
-	"strings"
 
+	"github.com/attestantio/dirk/util"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	zerologger "github.com/rs/zerolog/log"
@@ -42,30 +42,7 @@ func initLogging() error {
 	}
 
 	// Set the local logger from the global logger.
-	log = zerologger.Logger.With().Logger().Level(logLevel(viper.GetString("log-level")))
+	log = zerologger.Logger.With().Logger().Level(util.LogLevel(""))
 
 	return nil
-}
-
-// logLevel converts a string to a log level.
-// It returns the user-supplied level by default.
-func logLevel(input string) zerolog.Level {
-	switch strings.ToLower(input) {
-	case "none":
-		return zerolog.Disabled
-	case "trace":
-		return zerolog.TraceLevel
-	case "debug":
-		return zerolog.DebugLevel
-	case "warn", "warning":
-		return zerolog.WarnLevel
-	case "info", "information":
-		return zerolog.InfoLevel
-	case "err", "error":
-		return zerolog.ErrorLevel
-	case "fatal":
-		return zerolog.FatalLevel
-	default:
-		return log.GetLevel()
-	}
 }

--- a/util/logging.go
+++ b/util/logging.go
@@ -1,0 +1,64 @@
+// Copyright © 2021 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+)
+
+// LogLevel returns the best log level for the path.
+func LogLevel(path string) zerolog.Level {
+	if path == "" {
+		return stringToLevel(viper.GetString("log-level"))
+	}
+
+	key := fmt.Sprintf("%s.log-level", path)
+	if viper.GetString(key) != "" {
+		return stringToLevel(viper.GetString(key))
+	}
+	// Lop off the child and try again.
+	lastPeriod := strings.LastIndex(path, ".")
+	if lastPeriod == -1 {
+		return LogLevel("")
+	}
+	return LogLevel(path[0:lastPeriod])
+}
+
+// stringtoLevel converts a string to a log level.
+// It returns the user-supplied level by default.
+func stringToLevel(input string) zerolog.Level {
+	switch strings.ToLower(input) {
+	case "none":
+		return zerolog.Disabled
+	case "trace":
+		return zerolog.TraceLevel
+	case "debug":
+		return zerolog.DebugLevel
+	case "warn", "warning":
+		return zerolog.WarnLevel
+	case "info", "information":
+		return zerolog.InfoLevel
+	case "err", "error":
+		return zerolog.ErrorLevel
+	case "fatal":
+		return zerolog.FatalLevel
+	default:
+		return zerologger.Logger.GetLevel()
+	}
+}

--- a/util/logging_test.go
+++ b/util/logging_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2021 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/attestantio/dirk/util"
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogLevel(t *testing.T) {
+	zerologger.Logger = zerologger.Logger.Level(zerolog.DebugLevel)
+
+	tests := []struct {
+		name  string
+		vars  map[string]string
+		path  string
+		level zerolog.Level
+	}{
+		{
+			name:  "Empty",
+			path:  "",
+			level: zerolog.DebugLevel,
+		},
+		{
+			name:  "Root",
+			path:  ".",
+			level: zerolog.DebugLevel,
+		},
+		{
+			name: "TopLevel",
+			vars: map[string]string{
+				"log-level": "info",
+			},
+			path:  "",
+			level: zerolog.InfoLevel,
+		},
+		{
+			name: "SingleLevel",
+			vars: map[string]string{
+				"log-level": "info",
+			},
+			path:  "a",
+			level: zerolog.InfoLevel,
+		},
+		{
+			name: "MultiLevel",
+			vars: map[string]string{
+				"log-level": "info",
+			},
+			path:  "a.b.c",
+			level: zerolog.InfoLevel,
+		},
+		{
+			name: "Override",
+			vars: map[string]string{
+				"log-level":     "info",
+				"a.b.log-level": "Warn",
+			},
+			path:  "a.b.c",
+			level: zerolog.WarnLevel,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			viper.Reset()
+
+			for k, v := range test.vars {
+				viper.Set(k, v)
+			}
+			level := util.LogLevel(test.path)
+			require.Equal(t, test.level, level)
+		})
+	}
+}


### PR DESCRIPTION
This uses log levels of the form <module>.log-level, with hierarchical configuration to make it easy to have local overrides from the global setting.

It uses the standard util.LogLevel call to achieve this, removing some old code and cleaning up the initialisation code.