### PR TITLE
Send command errors to stderr.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Development
   - add Amazon Secrets Manager (ASM) confidant
+  - print command errors to stderr
 
 # Version 1.1.0
   - garbage collect the slashing database on startup to reduce on-disk size

--- a/main.go
+++ b/main.go
@@ -93,7 +93,10 @@ func main() {
 	}
 
 	// runCommands will not return if a command is run.
-	runCommands(ctx, majordomo)
+	exit, exitCode := runCommands(ctx, majordomo)
+	if exit {
+		os.Exit(exitCode)
+	}
 
 	if err := initLogging(); err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialise logging")
@@ -259,19 +262,19 @@ func initTracing() (io.Closer, error) {
 	return closer, nil
 }
 
-func runCommands(ctx context.Context, majordomo majordomo.Service) {
+func runCommands(ctx context.Context, majordomo majordomo.Service) (bool, int) {
 	if viper.GetBool("version") {
 		fmt.Printf("%s\n", ReleaseVersion)
-		os.Exit(0)
+		return true, 0
 	}
 
 	if viper.GetBool("show-certificates") {
 		err := cmd.ShowCertificates(ctx, majordomo)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "show-certificates failed: %v\n", err)
-			os.Exit(1)
+			return true, 1
 		}
-		os.Exit(0)
+		return true, 0
 	}
 
 	if viper.GetBool("show-permissions") {
@@ -288,16 +291,19 @@ func runCommands(ctx context.Context, majordomo majordomo.Service) {
 			}
 		}
 		checker.DumpPermissions(permissions)
-		os.Exit(0)
+		return true, 0
 	}
 
 	if viper.GetBool("export-slashing-protection") {
-		exportSlashingProtection(ctx)
+		return true, exportSlashingProtection(ctx)
 	}
 
 	if viper.GetBool("import-slashing-protection") {
-		importSlashingProtection(ctx)
+		return true, importSlashingProtection(ctx)
 	}
+
+	// No command run so no need to exit.
+	return false, 0
 }
 
 func startServices(ctx context.Context, majordomo majordomo.Service, monitor metrics.Service) error {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,8 @@ func runCommands(ctx context.Context, majordomo majordomo.Service) {
 	if viper.GetBool("show-certificates") {
 		err := cmd.ShowCertificates(ctx, majordomo)
 		if err != nil {
-			log.Fatal().Err(err).Msg("show-certificates failed")
+			fmt.Fprintf(os.Stderr, "show-certificates failed: %v\n", err)
+			os.Exit(1)
 		}
 		os.Exit(0)
 	}

--- a/slashingprotection.go
+++ b/slashingprotection.go
@@ -63,19 +63,19 @@ type SlashingProtectionAttestation struct {
 func exportSlashingProtection(ctx context.Context) {
 	protection, err := fetchSlashingProtection(ctx)
 	if err != nil {
-		fmt.Printf("%v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to obtain slashing protection information: %v\n", err)
 		os.Exit(1)
 	}
 
 	data, err := json.Marshal(protection)
 	if err != nil {
-		fmt.Printf("Failed to generate output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to generate output: %v\n", err)
 		os.Exit(1)
 	}
 
 	if viper.GetString("slashing-protection-file") != "" {
 		if err := ioutil.WriteFile(viper.GetString("slashing-protection-file"), data, 0600); err != nil {
-			fmt.Printf("Failed to generate output: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to write output: %v\n", err)
 			os.Exit(1)
 		}
 	} else {

--- a/slashingprotection.go
+++ b/slashingprotection.go
@@ -60,28 +60,28 @@ type SlashingProtectionAttestation struct {
 }
 
 // exportSlashingProtection is a command to export the slashing protection database.
-func exportSlashingProtection(ctx context.Context) {
+func exportSlashingProtection(ctx context.Context) int {
 	protection, err := fetchSlashingProtection(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to obtain slashing protection information: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	data, err := json.Marshal(protection)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to generate output: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
 
 	if viper.GetString("slashing-protection-file") != "" {
 		if err := ioutil.WriteFile(viper.GetString("slashing-protection-file"), data, 0600); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to write output: %v\n", err)
-			os.Exit(1)
+			return 1
 		}
 	} else {
 		fmt.Println(string(data))
 	}
-	os.Exit(0)
+	return 0
 }
 
 // fetchSlashingProtection obtains the slashing protection database.
@@ -140,28 +140,28 @@ func fetchSlashingProtection(ctx context.Context) (*SlashingProtection, error) {
 }
 
 // importSlashingProtection is a command to import a slashing protection database.
-func importSlashingProtection(ctx context.Context) {
+func importSlashingProtection(ctx context.Context) int {
 	if viper.GetString("slashing-protection-file") == "" {
-		fmt.Println("Slashing protection file required for import")
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Slashing protection file required for import\n")
+		return 1
 	}
 	data, err := ioutil.ReadFile(viper.GetString("slashing-protection-file"))
 	if err != nil {
-		fmt.Printf("Failed to read slashing protection file: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Failed to read slashing protection file: %v\n", err)
+		return 1
 	}
 
 	var protection SlashingProtection
 	if err := json.Unmarshal(data, &protection); err != nil {
-		fmt.Printf("Failed to parse slashing protection file: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Failed to parse slashing protection file: %v\n", err)
+		return 1
 	}
 	if err := storeSlashingProtection(ctx, &protection); err != nil {
-		fmt.Printf("Failed to store slashing protection: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(os.Stderr, "Failed to store slashing protection: %v\n", err)
+		return 1
 	}
 
-	os.Exit(0)
+	return 0
 }
 
 // storeSlashingProtection updates the slashing protection database.


### PR DESCRIPTION
Commands are run before logging is initialised, so any errors for commands must be sent to stderr rather than the logging system.