### PR TITLE
Change gsm credential logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -570,13 +570,13 @@ func initMajordomo(ctx context.Context) (majordomo.Service, error) {
 	}
 
 	if viper.GetString("majordomo.gsm.project") != "" {
-		var gsmCredentialPath string
+		var gsmCredentialsPath string
 		if viper.GetString("majordomo.gsm.credentials") != "" {
-			gsmCredentialPath = resolvePath(viper.GetString("majordomo.gsm.credentials"))
+			gsmCredentialsPath = resolvePath(viper.GetString("majordomo.gsm.credentials"))
 		}
 		gsmConfidant, err := gsmconfidant.New(ctx,
 			gsmconfidant.WithLogLevel(util.LogLevel("majordomo.confidants.gsm")),
-			gsmconfidant.WithCredentialsPath(gsmCredentialPath),
+			gsmconfidant.WithCredentialsPath(gsmCredentialsPath),
 			gsmconfidant.WithProject(viper.GetString("majordomo.gsm.project")),
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -569,10 +569,14 @@ func initMajordomo(ctx context.Context) (majordomo.Service, error) {
 		}
 	}
 
-	if viper.GetString("majordomo.gsm.credentials") != "" {
+	if viper.GetString("majordomo.gsm.project") != "" {
+		var gsmCredentialPath string
+		if viper.GetString("majordomo.gsm.credentials") != "" {
+			gsmCredentialPath = resolvePath(viper.GetString("majordomo.gsm.credentials"))
+		}
 		gsmConfidant, err := gsmconfidant.New(ctx,
 			gsmconfidant.WithLogLevel(util.LogLevel("majordomo.confidants.gsm")),
-			gsmconfidant.WithCredentialsPath(resolvePath(viper.GetString("majordomo.gsm.credentials"))),
+			gsmconfidant.WithCredentialsPath(gsmCredentialPath),
 			gsmconfidant.WithProject(viper.GetString("majordomo.gsm.project")),
 		)
 		if err != nil {


### PR DESCRIPTION
It is possible to use vm's attached `service account` for accessing gsm secrets. And by default `go-majordomo` supports it.
Here is a simple example for testing:
```
package main

import (
  "context"
  "fmt"

  "github.com/wealdtech/go-majordomo/confidants/gsm"
  standardmajordomo "github.com/wealdtech/go-majordomo/standard"
)

func main() {
  ctx := context.Background()
  // Create the majordomo service.
  service, err := standardmajordomo.New(ctx)
  if err != nil {
   panic(err)
  }

  // Create and register the file confidant.
  confidant, err := gsm.New(ctx, gsm.WithProject("mytestproject"), gsm.WithCredentialsPath(""))
  if err != nil {
   panic(err)
  }
  err = service.RegisterConfidant(ctx, confidant)
  if err != nil {
   panic(err)
  }

  // Fetch a value from the service.
  value, err := service.Fetch(ctx, "gsm:///test22")
  if err != nil {
   panic(err)
  }
  fmt.Printf("Value is %s\n", string(value))
}
```
So here is a PR for support this functionality on the Dirk side. 
Also this PR is related to https://github.com/attestantio/dirk/issues/29
