### PR TITLE
Increase generation phase timeout and make generation proccess parallel

### DIFF
--- a/services/process/standard/generation.go
+++ b/services/process/standard/generation.go
@@ -66,8 +66,8 @@ func (s *Service) getGeneration(ctx context.Context, account string) (*generatio
 		return nil, ErrNotFound
 	}
 
-	// Generations more than 10 seconds old need to be removed.
-	if time.Since(generator.processStarted) > 10*time.Second {
+	// Generations more than 70 seconds old need to be removed.
+	if time.Since(generator.processStarted) > 70*time.Second {
 		// Been too long; remove it.
 		log.Debug().Str("account", account).Msg("Generation been active too long; invalidating")
 		delete(s.generations, account)

--- a/services/process/standard/service_test.go
+++ b/services/process/standard/service_test.go
@@ -482,8 +482,8 @@ func TestTimeout(t *testing.T) {
 	err = service.OnPrepare(ctx, 1, "Test/Test", []byte("test"), 2, endpoints)
 	require.NoError(t, err)
 
-	// Timeout for requests is 10 seconds.
-	time.Sleep(11 * time.Second)
+	// Timeout for requests is 70 seconds.
+	time.Sleep(71 * time.Second)
 
 	err = service.OnAbort(ctx, 1, "Test/Test")
 	assert.EqualError(t, err, standardprocess.ErrNotInProgress.Error())


### PR DESCRIPTION
We are using s3 to store wallets/accounts. If we have about 200 keys, generation account time is about 21 seconds. This is a small improvement decreasing generation account time to 15 seconds for 200 keys.