### PR TITLE
Fix signer handler

### DIFF
--- a/services/api/grpc/handlers/signer/sign.go
+++ b/services/api/grpc/handlers/signer/sign.go
@@ -38,7 +38,7 @@ func (h *Handler) Sign(ctx context.Context, req *pb.SignRequest) (*pb.SignRespon
 		res.State = pb.ResponseState_DENIED
 		return res, nil
 	}
-	if !strings.Contains(req.GetAccount(), "/") {
+	if req.GetPublicKey() == nil && !strings.Contains(req.GetAccount(), "/") {
 		log.Warn().Str("result", "denied").Msg("Invalid account specified")
 		res.State = pb.ResponseState_DENIED
 		return res, nil


### PR DESCRIPTION
The signer handler was checking if the account name contains a `'/'` character even though a public key was passed, resulting impossible to request a sign using public keys.