### PR TITLE
Allow badger.DB access on systems without mmap().

### DIFF
--- a/rules/standard/storage.go
+++ b/rules/standard/storage.go
@@ -46,7 +46,13 @@ func NewStore(ctx context.Context,
 	opt.Logger = loggers.NewBadgerLogger(log)
 	db, err := badger.Open(opt)
 	if err != nil {
-		return nil, err
+		// Fallback for systems that don't support mmap.
+		opt.ValueLogLoadingMode = options.FileIO
+		db, err = badger.Open(opt)
+		if err != nil {
+			return nil, err
+		}
+		log.Info().Str("db", base).Msg("badger db opened without mmap support.")
 	}
 
 	var ticker *time.Ticker


### PR DESCRIPTION
In Open Enclave, the mmap syscall is unsupported. Luckily, badger can also access the database with plain file ops. This change implements that as fallback, in case opening the database with mmap() fails.