### PR TITLE
Add RFC 6125-compliant SAN support for client certificate identity extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version X
+  - support SAN for client certificates
+
 # Version 1.2.1
   - run slashing protection database garbage collection periodically
   - add commit hash to log on startup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,9 @@ certificates:
   # ca-cert is the certificate of the CA that issued the client certificates.  If not present Dirk will use
   # the standard CA certificates supplied with the server.
   ca-cert: file:///home/me/dirk/security/certificates/ca.crt
+  # Note: Client certificates should include the client identity in Subject Alternative Names (SAN).
+  # Dirk supports DNS names, IP addresses, and email addresses in SAN fields, with DNS names preferred.
+  # Legacy certificates using only Common Name (CN) are still supported for backward compatibility.
 # storage-path is the path where information created by the slashing protection system is stored.  If not
 # supplied it will default to using the 'storage' directory in the user's home directory.
 storage-path: /home/me/dirk/protection

--- a/services/api/grpc/handlers/helpers.go
+++ b/services/api/grpc/handlers/helpers.go
@@ -30,6 +30,17 @@ func GenerateCredentials(ctx context.Context) *checker.Credentials {
 	if client, ok := ctx.Value(&interceptors.ClientName{}).(string); ok {
 		res.Client = client
 	}
+	if identitySource, ok := ctx.Value(&interceptors.ClientIdentitySource{}).(string); ok {
+		res.ClientIdentitySource = identitySource
+	}
+	if certSANs, ok := ctx.Value(&interceptors.ClientCertificateSANs{}).(*interceptors.CertificateSANs); ok {
+		// Convert from interceptors type to checker type
+		res.ClientCertificateSANs = &checker.CertificateSANs{
+			DNSNames:       certSANs.DNSNames,
+			IPAddresses:    certSANs.IPAddresses,
+			EmailAddresses: certSANs.EmailAddresses,
+		}
+	}
 	if ip, ok := ctx.Value(&interceptors.ExternalIP{}).(string); ok {
 		res.IP = ip
 	}

--- a/services/api/grpc/handlers/helpers.go
+++ b/services/api/grpc/handlers/helpers.go
@@ -34,7 +34,7 @@ func GenerateCredentials(ctx context.Context) *checker.Credentials {
 		res.ClientIdentitySource = identitySource
 	}
 	if certSANs, ok := ctx.Value(&interceptors.ClientCertificateSANs{}).(*interceptors.CertificateSANs); ok {
-		// Convert from interceptors type to checker type
+		// Convert from interceptors type to checker type.
 		res.ClientCertificateSANs = &checker.CertificateSANs{
 			DNSNames:       certSANs.DNSNames,
 			IPAddresses:    certSANs.IPAddresses,

--- a/services/api/grpc/interceptors/clientinfo.go
+++ b/services/api/grpc/interceptors/clientinfo.go
@@ -93,22 +93,22 @@ type CertificateSANs struct {
 
 // extractClientIdentity extracts the client identity from an x509 certificate.
 func extractClientIdentity(cert *x509.Certificate) (string, string) {
-	// Priority 1: DNS names from SAN (RFC 6125 compliant)
+	// Priority 1: DNS names from SAN (RFC 6125 compliant).
 	if len(cert.DNSNames) > 0 && cert.DNSNames[0] != "" {
 		return cert.DNSNames[0], "san-dns"
 	}
 
-	// Priority 2: IP addresses from SAN
+	// Priority 2: IP addresses from SAN.
 	if len(cert.IPAddresses) > 0 {
 		return cert.IPAddresses[0].String(), "san-ip"
 	}
 
-	// Priority 3: Email addresses from SAN
+	// Priority 3: Email addresses from SAN.
 	if len(cert.EmailAddresses) > 0 && cert.EmailAddresses[0] != "" {
 		return cert.EmailAddresses[0], "san-email"
 	}
 
-	// Priority 4: CN fallback for backward compatibility with legacy certificates
+	// Priority 4: CN fallback for backward compatibility with legacy certificates.
 	if cert.Subject.CommonName != "" {
 		return cert.Subject.CommonName, "cn"
 	}

--- a/services/api/grpc/interceptors/clientinfo.go
+++ b/services/api/grpc/interceptors/clientinfo.go
@@ -15,6 +15,7 @@ package interceptors
 
 import (
 	"context"
+	"crypto/x509"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -23,10 +24,37 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// ClientName is a context tag for the CN of the client's certificate.
+// ClientName is a context tag for the identity extracted from the client's certificate.
 type ClientName struct{}
 
-// ClientInfoInterceptor adds the client certificate common name to incoming requests.
+// ClientIdentitySource is a context tag for the source of the client identity.
+type ClientIdentitySource struct{}
+
+// ClientCertificateSANs is a context tag for all SANs from the client's certificate.
+type ClientCertificateSANs struct{}
+
+// ClientInfoInterceptor adds the client certificate identity to incoming requests.
+//
+// Identity is extracted from the client certificate using a prioritized approach
+// that complies with RFC 6125 (domain name verification) by preferring Subject
+// Alternative Name (SAN) fields over the deprecated Common Name (CN).
+//
+// The identity extraction follows this priority order:
+//  1. DNS names from SAN - Most common for service-to-service authentication
+//  2. IP addresses from SAN - Valid for direct IP-based connections
+//  3. Email addresses from SAN - Common in client certificates for user identity
+//  4. Common Name (CN) - Fallback for backward compatibility with legacy certificates
+//
+// Note on URI SANs: We intentionally do not support URI-based SANs (e.g., SPIFFE IDs,
+// https:// URIs) because:
+//   - They are not commonly used in Dirk's validator/signer architecture
+//   - URI schemes vary widely and require additional parsing/validation logic
+//   - The permission system expects simple string identities (hostnames, IPs, emails)
+//   - Adding URI support would complicate authorization rules without clear benefit
+//
+// If URI SAN support is needed in the future, it should be added with careful
+// consideration of which URI schemes to accept and how to normalize them for
+// permission matching.
 func ClientInfoInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		grpcPeer, ok := peer.FromContext(ctx)
@@ -40,10 +68,69 @@ func ClientInfoInterceptor() grpc.UnaryServerInterceptor {
 			peerCerts := authState.PeerCertificates
 			if len(peerCerts) > 0 {
 				peerCert := peerCerts[0]
-				newCtx = context.WithValue(ctx, &ClientName{}, peerCert.Subject.CommonName)
+				clientIdentity, identitySource := extractClientIdentity(peerCert)
+				certificateSANs := extractCertificateSANs(peerCert)
+
+				newCtx = context.WithValue(ctx, &ClientName{}, clientIdentity)
+				newCtx = context.WithValue(newCtx, &ClientIdentitySource{}, identitySource)
+				newCtx = context.WithValue(newCtx, &ClientCertificateSANs{}, certificateSANs)
 			}
 		}
 
 		return handler(newCtx, req)
 	}
+}
+
+// CertificateSANs contains all Subject Alternative Name values from a certificate.
+type CertificateSANs struct {
+	// DNSNames contains all DNS names from the certificate's SAN extension.
+	DNSNames []string
+	// IPAddresses contains all IP addresses from the certificate's SAN extension (as strings).
+	IPAddresses []string
+	// EmailAddresses contains all email addresses from the certificate's SAN extension.
+	EmailAddresses []string
+}
+
+// extractClientIdentity extracts the client identity from an x509 certificate.
+func extractClientIdentity(cert *x509.Certificate) (string, string) {
+	// Priority 1: DNS names from SAN (RFC 6125 compliant)
+	if len(cert.DNSNames) > 0 && cert.DNSNames[0] != "" {
+		return cert.DNSNames[0], "san-dns"
+	}
+
+	// Priority 2: IP addresses from SAN
+	if len(cert.IPAddresses) > 0 {
+		return cert.IPAddresses[0].String(), "san-ip"
+	}
+
+	// Priority 3: Email addresses from SAN
+	if len(cert.EmailAddresses) > 0 && cert.EmailAddresses[0] != "" {
+		return cert.EmailAddresses[0], "san-email"
+	}
+
+	// Priority 4: CN fallback for backward compatibility with legacy certificates
+	if cert.Subject.CommonName != "" {
+		return cert.Subject.CommonName, "cn"
+	}
+
+	return "", ""
+}
+
+// extractCertificateSANs extracts all Subject Alternative Names from a certificate.
+func extractCertificateSANs(cert *x509.Certificate) *CertificateSANs {
+	sans := &CertificateSANs{
+		DNSNames:       make([]string, len(cert.DNSNames)),
+		IPAddresses:    make([]string, len(cert.IPAddresses)),
+		EmailAddresses: make([]string, len(cert.EmailAddresses)),
+	}
+
+	copy(sans.DNSNames, cert.DNSNames)
+
+	for i, ip := range cert.IPAddresses {
+		sans.IPAddresses[i] = ip.String()
+	}
+
+	copy(sans.EmailAddresses, cert.EmailAddresses)
+
+	return sans
 }

--- a/services/api/grpc/interceptors/clientinfo_internal_test.go
+++ b/services/api/grpc/interceptors/clientinfo_internal_test.go
@@ -1,0 +1,527 @@
+// Copyright © 2020 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptors
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractClientIdentity(t *testing.T) {
+	tests := []struct {
+		name         string
+		cert         *x509.Certificate
+		wantIdentity string
+		wantSource   string
+		description  string
+	}{
+		{
+			name: "SAN DNS single",
+			cert: &x509.Certificate{
+				DNSNames: []string{"validator-01.example.com"},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "validator-01.example.com",
+			wantSource:   "san-dns",
+			description:  "Single DNS name in SAN should be preferred over CN",
+		},
+		{
+			name: "SAN DNS multiple",
+			cert: &x509.Certificate{
+				DNSNames: []string{
+					"primary.example.com",
+					"secondary.example.com",
+					"tertiary.example.com",
+				},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "primary.example.com",
+			wantSource:   "san-dns",
+			description:  "First DNS name should be selected when multiple are present",
+		},
+		{
+			name: "SAN IP single IPv4",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{net.ParseIP("192.168.1.100")},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "192.168.1.100",
+			wantSource:   "san-ip",
+			description:  "IPv4 address in SAN should be used when no DNS names present",
+		},
+		{
+			name: "SAN IP single IPv6",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{net.ParseIP("2001:db8::1")},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "2001:db8::1",
+			wantSource:   "san-ip",
+			description:  "IPv6 address in SAN should be used when no DNS names present",
+		},
+		{
+			name: "SAN IP multiple",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("10.0.0.1"),
+					net.ParseIP("10.0.0.2"),
+					net.ParseIP("2001:db8::1"),
+				},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "10.0.0.1",
+			wantSource:   "san-ip",
+			description:  "First IP address should be selected when multiple are present",
+		},
+		{
+			name: "SAN Email single",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{"validator@example.com"},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "validator@example.com",
+			wantSource:   "san-email",
+			description:  "Email address in SAN should be used when no DNS or IP present",
+		},
+		{
+			name: "SAN Email multiple",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{
+					"primary@example.com",
+					"secondary@example.com",
+					"tertiary@example.com",
+				},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "primary@example.com",
+			wantSource:   "san-email",
+			description:  "First email should be selected when multiple are present",
+		},
+		{
+			name: "CN only (legacy)",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "legacy-client.example.com",
+				},
+			},
+			wantIdentity: "legacy-client.example.com",
+			wantSource:   "cn",
+			description:  "CN should be used as fallback when no SAN present",
+		},
+		{
+			name: "SAN DNS priority over IP",
+			cert: &x509.Certificate{
+				DNSNames:    []string{"dns-name.example.com"},
+				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "dns-name.example.com",
+			wantSource:   "san-dns",
+			description:  "DNS name should be preferred over IP address",
+		},
+		{
+			name: "SAN DNS priority over Email",
+			cert: &x509.Certificate{
+				DNSNames:       []string{"dns-name.example.com"},
+				EmailAddresses: []string{"email@example.com"},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "dns-name.example.com",
+			wantSource:   "san-dns",
+			description:  "DNS name should be preferred over email address",
+		},
+		{
+			name: "SAN IP priority over Email",
+			cert: &x509.Certificate{
+				IPAddresses:    []net.IP{net.ParseIP("192.168.1.1")},
+				EmailAddresses: []string{"email@example.com"},
+				Subject: pkix.Name{
+					CommonName: "should-not-use-this",
+				},
+			},
+			wantIdentity: "192.168.1.1",
+			wantSource:   "san-ip",
+			description:  "IP address should be preferred over email address",
+		},
+		{
+			name: "All SAN types present",
+			cert: &x509.Certificate{
+				DNSNames:       []string{"dns.example.com"},
+				IPAddresses:    []net.IP{net.ParseIP("10.0.0.1")},
+				EmailAddresses: []string{"email@example.com"},
+				Subject: pkix.Name{
+					CommonName: "cn.example.com",
+				},
+			},
+			wantIdentity: "dns.example.com",
+			wantSource:   "san-dns",
+			description:  "DNS should win when all identity types are present",
+		},
+		{
+			name: "Empty DNS name ignored",
+			cert: &x509.Certificate{
+				DNSNames:    []string{""},
+				IPAddresses: []net.IP{net.ParseIP("192.168.1.1")},
+				Subject: pkix.Name{
+					CommonName: "fallback.example.com",
+				},
+			},
+			wantIdentity: "192.168.1.1",
+			wantSource:   "san-ip",
+			description:  "Empty DNS name should be skipped, next priority used",
+		},
+		{
+			name: "Empty Email ignored",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{""},
+				Subject: pkix.Name{
+					CommonName: "fallback.example.com",
+				},
+			},
+			wantIdentity: "fallback.example.com",
+			wantSource:   "cn",
+			description:  "Empty email address should be skipped, CN used as fallback",
+		},
+		{
+			name: "No identity available",
+			cert: &x509.Certificate{
+				Subject: pkix.Name{
+					CommonName: "",
+				},
+			},
+			wantIdentity: "",
+			wantSource:   "",
+			description:  "Empty string and source when no identity available",
+		},
+		{
+			name: "Complex realistic scenario - modern CA",
+			cert: &x509.Certificate{
+				DNSNames: []string{
+					"validator-prod-01.validators.example.com",
+					"validator-prod-01.internal",
+					"10-0-1-100.validators.example.com",
+				},
+				IPAddresses: []net.IP{
+					net.ParseIP("10.0.1.100"),
+					net.ParseIP("192.168.50.10"),
+				},
+				Subject: pkix.Name{
+					CommonName: "",
+				},
+			},
+			wantIdentity: "validator-prod-01.validators.example.com",
+			wantSource:   "san-dns",
+			description:  "Modern CA certificate with multiple SANs and empty CN",
+		},
+		{
+			name: "Service certificate with email",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{
+					"service-account-validator@example.com",
+					"backup-validator@example.com",
+				},
+				Subject: pkix.Name{
+					CommonName: "Service Account Validator",
+				},
+			},
+			wantIdentity: "service-account-validator@example.com",
+			wantSource:   "san-email",
+			description:  "Service certificate using email-based identity",
+		},
+		{
+			name: "Certificate with unusual but technically valid emails",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{
+					"test@localhost", // Local email without domain
+					"user@127.0.0.1", // IP address as domain
+					"valid@example.com",
+				},
+				Subject: pkix.Name{
+					CommonName: "unusual-email-client",
+				},
+			},
+			wantIdentity: "test@localhost",
+			wantSource:   "san-email",
+			description:  "Unusual but syntactically valid emails are accepted as identities",
+		},
+		{
+			name: "Certificate with private/reserved IP addresses",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("127.0.0.1"),     // localhost
+					net.ParseIP("192.168.1.100"), // private network
+					net.ParseIP("10.0.0.1"),      // private network
+				},
+				Subject: pkix.Name{
+					CommonName: "private-ip-client",
+				},
+			},
+			wantIdentity: "127.0.0.1",
+			wantSource:   "san-ip",
+			description:  "Private and reserved IP addresses are accepted as valid identities",
+		},
+		{
+			name: "Certificate with IPv6 localhost",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("::1"),         // IPv6 localhost
+					net.ParseIP("2001:db8::1"), // IPv6 documentation address
+				},
+				Subject: pkix.Name{
+					CommonName: "ipv6-client",
+				},
+			},
+			wantIdentity: "::1",
+			wantSource:   "san-ip",
+			description:  "IPv6 addresses including localhost are properly handled",
+		},
+		{
+			name: "Certificate with public IP when localhost expected",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("8.8.8.8"), // Public DNS server IP
+				},
+				DNSNames: []string{"localhost"}, // But claims to be localhost
+				Subject: pkix.Name{
+					CommonName: "localhost",
+				},
+			},
+			wantIdentity: "localhost",
+			wantSource:   "san-dns",
+			description:  "DNS names take priority over IPs, even with mismatched values",
+		},
+		{
+			name: "Certificate with wrong domain email",
+			cert: &x509.Certificate{
+				EmailAddresses: []string{
+					"admin@wrong-domain.com", // Email for different domain
+				},
+				DNSNames: []string{"validator.example.com"},
+				Subject: pkix.Name{
+					CommonName: "validator.example.com",
+				},
+			},
+			wantIdentity: "validator.example.com",
+			wantSource:   "san-dns",
+			description:  "DNS identity takes priority over email, regardless of email domain",
+		},
+		{
+			name: "Localhost IP",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("127.0.0.1"),
+				},
+				Subject: pkix.Name{
+					CommonName: "localhost",
+				},
+			},
+			wantIdentity: "127.0.0.1",
+			wantSource:   "san-ip",
+			description:  "Localhost IP address should be handled correctly",
+		},
+		{
+			name: "IPv6 localhost",
+			cert: &x509.Certificate{
+				IPAddresses: []net.IP{
+					net.ParseIP("::1"),
+				},
+				Subject: pkix.Name{
+					CommonName: "localhost",
+				},
+			},
+			wantIdentity: "::1",
+			wantSource:   "san-ip",
+			description:  "IPv6 localhost should be handled correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use reflection to call the unexported function
+			// In a real test, we'd either export it or test through the interceptor
+			identity, source := extractClientIdentity(tt.cert)
+
+			assert.Equal(t, tt.wantIdentity, identity,
+				"Identity mismatch: %s", tt.description)
+			assert.Equal(t, tt.wantSource, source,
+				"Source mismatch: %s", tt.description)
+		})
+	}
+}
+
+func TestExtractCertificateSANs(t *testing.T) {
+	tests := []struct {
+		name     string
+		cert     *x509.Certificate
+		wantSANs *CertificateSANs
+	}{
+		{
+			name: "All SAN types populated",
+			cert: &x509.Certificate{
+				DNSNames: []string{
+					"dns1.example.com",
+					"dns2.example.com",
+				},
+				IPAddresses: []net.IP{
+					net.ParseIP("192.168.1.1"),
+					net.ParseIP("2001:db8::1"),
+				},
+				EmailAddresses: []string{
+					"email1@example.com",
+					"email2@example.com",
+				},
+			},
+			wantSANs: &CertificateSANs{
+				DNSNames: []string{
+					"dns1.example.com",
+					"dns2.example.com",
+				},
+				IPAddresses: []string{
+					"192.168.1.1",
+					"2001:db8::1",
+				},
+				EmailAddresses: []string{
+					"email1@example.com",
+					"email2@example.com",
+				},
+			},
+		},
+		{
+			name: "Empty certificate",
+			cert: &x509.Certificate{},
+			wantSANs: &CertificateSANs{
+				DNSNames:       []string{},
+				IPAddresses:    []string{},
+				EmailAddresses: []string{},
+			},
+		},
+		{
+			name: "Only DNS names",
+			cert: &x509.Certificate{
+				DNSNames: []string{"example.com"},
+			},
+			wantSANs: &CertificateSANs{
+				DNSNames:       []string{"example.com"},
+				IPAddresses:    []string{},
+				EmailAddresses: []string{},
+			},
+		},
+		{
+			name: "Many SANs",
+			cert: &x509.Certificate{
+				DNSNames: []string{
+					"host1.example.com",
+					"host2.example.com",
+					"host3.example.com",
+					"host4.example.com",
+					"host5.example.com",
+				},
+				IPAddresses: []net.IP{
+					net.ParseIP("10.0.0.1"),
+					net.ParseIP("10.0.0.2"),
+					net.ParseIP("10.0.0.3"),
+				},
+				EmailAddresses: []string{
+					"admin@example.com",
+				},
+			},
+			wantSANs: &CertificateSANs{
+				DNSNames: []string{
+					"host1.example.com",
+					"host2.example.com",
+					"host3.example.com",
+					"host4.example.com",
+					"host5.example.com",
+				},
+				IPAddresses: []string{
+					"10.0.0.1",
+					"10.0.0.2",
+					"10.0.0.3",
+				},
+				EmailAddresses: []string{
+					"admin@example.com",
+				},
+			},
+		},
+		{
+			name: "Unusual but valid SAN values",
+			cert: &x509.Certificate{
+				DNSNames: []string{
+					"localhost",
+					"my-server.internal",
+				},
+				IPAddresses: []net.IP{
+					net.ParseIP("127.0.0.1"),
+					net.ParseIP("::1"),
+					net.ParseIP("192.168.1.1"),
+				},
+				EmailAddresses: []string{
+					"root@localhost",
+					"user@192.168.1.100",
+					"service@company.internal",
+				},
+			},
+			wantSANs: &CertificateSANs{
+				DNSNames: []string{
+					"localhost",
+					"my-server.internal",
+				},
+				IPAddresses: []string{
+					"127.0.0.1",
+					"::1",
+					"192.168.1.1",
+				},
+				EmailAddresses: []string{
+					"root@localhost",
+					"user@192.168.1.100",
+					"service@company.internal",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sans := extractCertificateSANs(tt.cert)
+
+			require.NotNil(t, sans)
+			assert.Equal(t, tt.wantSANs.DNSNames, sans.DNSNames, "DNS names mismatch")
+			assert.Equal(t, tt.wantSANs.IPAddresses, sans.IPAddresses, "IP addresses mismatch")
+			assert.Equal(t, tt.wantSANs.EmailAddresses, sans.EmailAddresses, "Email addresses mismatch")
+		})
+	}
+}

--- a/services/checker/service.go
+++ b/services/checker/service.go
@@ -19,10 +19,25 @@ import "context"
 type Credentials struct {
 	// RequestID is the ID of the request.
 	RequestID string
-	// Client is the authenticated client.
+	// Client is the authenticated client identity (extracted from certificate).
 	Client string
+	// ClientIdentitySource indicates where the Client identity came from.
+	// Possible values: "san-dns", "san-ip", "san-email", "cn", or "" if no identity.
+	ClientIdentitySource string
+	// ClientCertificateSANs contains all Subject Alternative Names from the client certificate.
+	ClientCertificateSANs *CertificateSANs
 	// IP is the originating IP address of the request.
 	IP string
+}
+
+// CertificateSANs contains all Subject Alternative Name values from a certificate.
+type CertificateSANs struct {
+	// DNSNames contains all DNS names from the certificate's SAN extension.
+	DNSNames []string
+	// IPAddresses contains all IP addresses from the certificate's SAN extension (as strings).
+	IPAddresses []string
+	// EmailAddresses contains all email addresses from the certificate's SAN extension.
+	EmailAddresses []string
 }
 
 // Service is the interface for checking client access to accounts.

--- a/services/checker/static/service.go
+++ b/services/checker/static/service.go
@@ -82,14 +82,14 @@ func (s *Service) Check(_ context.Context, credentials *checker.Credentials, acc
 		return false
 	}
 
-	// Build logger with client identity information
+	// Build logger with client identity information.
 	logContext := log.With().
 		Str("account", account).
 		Str("operation", operation).
 		Str("client", credentials.Client).
 		Str("client_identity_source", credentials.ClientIdentitySource)
 
-	// Add all available identities from certificate SANs for audit trail
+	// Add all available identities from certificate SANs for audit trail.
 	if credentials.ClientCertificateSANs != nil {
 		if len(credentials.ClientCertificateSANs.DNSNames) > 0 {
 			logContext = logContext.Strs("cert_dns_names", credentials.ClientCertificateSANs.DNSNames)

--- a/services/checker/static/service.go
+++ b/services/checker/static/service.go
@@ -81,7 +81,28 @@ func (s *Service) Check(_ context.Context, credentials *checker.Credentials, acc
 		log.Warn().Str("result", "denied").Msg("No client name")
 		return false
 	}
-	log := log.With().Str("account", account).Str("operation", operation).Str("client", credentials.Client).Str("account", account).Logger()
+
+	// Build logger with client identity information
+	logContext := log.With().
+		Str("account", account).
+		Str("operation", operation).
+		Str("client", credentials.Client).
+		Str("client_identity_source", credentials.ClientIdentitySource)
+
+	// Add all available identities from certificate SANs for audit trail
+	if credentials.ClientCertificateSANs != nil {
+		if len(credentials.ClientCertificateSANs.DNSNames) > 0 {
+			logContext = logContext.Strs("cert_dns_names", credentials.ClientCertificateSANs.DNSNames)
+		}
+		if len(credentials.ClientCertificateSANs.IPAddresses) > 0 {
+			logContext = logContext.Strs("cert_ip_addresses", credentials.ClientCertificateSANs.IPAddresses)
+		}
+		if len(credentials.ClientCertificateSANs.EmailAddresses) > 0 {
+			logContext = logContext.Strs("cert_email_addresses", credentials.ClientCertificateSANs.EmailAddresses)
+		}
+	}
+
+	log := logContext.Logger()
 
 	walletName, accountName, err := e2wallet.WalletAndAccountNames(account)
 	if err != nil {

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -129,7 +129,7 @@ func (*LogCapture) hasField(entry map[string]any, key string, value any) bool {
 		case float64:
 			return entryValue.(float64) == v
 		case []any:
-			// Handle slice comparison
+			// Handle slice comparison.
 			if entrySlice, ok := entryValue.([]any); ok {
 				if len(v) != len(entrySlice) {
 					return false

--- a/testing/logger/capture.go
+++ b/testing/logger/capture.go
@@ -128,6 +128,20 @@ func (*LogCapture) hasField(entry map[string]any, key string, value any) bool {
 			return float32(entryValue.(float64)) == v
 		case float64:
 			return entryValue.(float64) == v
+		case []any:
+			// Handle slice comparison
+			if entrySlice, ok := entryValue.([]any); ok {
+				if len(v) != len(entrySlice) {
+					return false
+				}
+				for i, expected := range v {
+					if i >= len(entrySlice) || expected != entrySlice[i] {
+						return false
+					}
+				}
+				return true
+			}
+			return false
 		default:
 			panic("unhandled type")
 		}


### PR DESCRIPTION
Implement Subject Alternative Name (SAN) prioritization over the deprecated Common Name (CN) field for extracting client identities from certificates, ensuring compatibility with modern certificate authorities while maintaining backward compatibility with legacy CN-only certificates.

## Changes:
  - Implement SAN-first identity extraction with priority order:
    1. DNS names from SAN (RFC 6125 compliant)
    2. IP addresses from SAN (IPv4 and IPv6)
    3. Email addresses from SAN
    4. Common Name (CN) as fallback for legacy certificates
  - Add comprehensive audit logging:
    - Log identity source (san-dns, san-ip, san-email, cn)
    - Log all SANs from certificate for security audit trail
    - Enhanced checker service logging with certificate details
  - Add comprehensive test coverage
  - Update documentation

  This implementation ensures:
  - RFC 6125 compliance for modern certificate standards
  - Backward compatibility with existing CN-only certificates
  - Support for modern CAs that issue SAN-only certificates
  - Full audit trail of certificate identities for security analysis

## Decisions required:

- [ ] Is the proposed priority order correct and desired? (we might want to extract and use DNS names only)
- [ ] Shall we go with a different approach? (Look at the **Alternative approaches** section below)
- [ ]  Shall we support URI-based SANs (SPIFFE IDs, HTTPS URIs)?  
> These are intentionally not supported as they are uncommon in validator/signer architectures and would complicate the permission matching system without clear benefit.
- [ ] Shall we validate SAN values correctness?
> Context:  

>  ✅ What Dirk Does Validate:
>   - Certificate signature and chain validity (via TLS)
>   - Certificate expiration (via TLS)
>   - Client certificate presence requirement
>   - Non-empty identity strings

> ❌ What Dirk Does NOT Validate:
>   - Email address format correctness
>   - IP address appropriateness for the context
>   - Domain ownership verification
>   - Identity-to-hostname matching

## Alternative approaches:
> Context: Proposed implementation only uses the first SAN entry, if cert has multiple SANs, others are ignored.

### Multiple Identity Support
Allow a certificate to have multiple valid identities, check authorization against all of them.

### Configurable Strategy
Let operators choose the behavior via configuration like:
```
certificates:
    identity-source: "san-preferred"  # Options: san-only, cn-only, san-preferred, cn-preferred, all
    san-types:                        # Which SAN types to consider
      - dns                           # DNS names
      # - email                       # Email addresses (if needed)
      # - uri                         # URIs (if needed)
```

### Other???