### PR TITLE
Support on-demand certificate reload on SIGHUP 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Version X
   - support SAN for client certificates
+  - support certificates reloading after a SIGHUP signal
 
 # Version 1.2.1
   - run slashing protection database garbage collection periodically

--- a/core/stores.go
+++ b/core/stores.go
@@ -104,7 +104,7 @@ func initFilesystemStore(ctx context.Context,
 	log.Trace().Str("name", storeDefinition.Name).Str("location", storeDefinition.Location).Msg("Adding filesystem store")
 
 	opts := make([]filesystem.Option, 0)
-	if len(storeDefinition.Passphrase) > 0 {
+	if storeDefinition.Passphrase != "" {
 		passphrase, err := majordomo.Fetch(ctx, storeDefinition.Passphrase)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to obtain passphrase")
@@ -129,7 +129,7 @@ func initS3Store(ctx context.Context,
 	log.Trace().Str("name", storeDefinition.Name).Str("location", storeDefinition.Location).Msg("Adding S3 store")
 
 	opts := make([]s3.Option, 0)
-	if len(storeDefinition.Passphrase) > 0 {
+	if storeDefinition.Passphrase != "" {
 		passphrase, err := majordomo.Fetch(ctx, storeDefinition.Passphrase)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to obtain passphrase")

--- a/core/stores.go
+++ b/core/stores.go
@@ -56,7 +56,7 @@ type S3StoreCredentials struct {
 	Secret string `mapstructure:"secret"`
 }
 
-// InitStores initialises the stores from a configuration.
+// InitStores initializes the stores from a configuration.
 func InitStores(ctx context.Context, majordomo majordomo.Service, storeDefinitions []*Store) ([]e2wtypes.Store, error) {
 	if len(storeDefinitions) == 0 {
 		log.Warn().Msg("No stores configured; using default")
@@ -176,7 +176,7 @@ func initScratchStore(_ context.Context,
 	return store
 }
 
-// initDefaultStores initialises the default stores.
+// initDefaultStores initializes the default stores.
 func initDefaultStores() []e2wtypes.Store {
 	res := make([]e2wtypes.Store, 1)
 	res[0] = filesystem.New()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,10 +35,17 @@ certificates:
   server-key: file:///home/me/dirk/security/certificates/myserver.example.com.key
   # ca-cert is the certificate of the CA that issued the client certificates.  If not present Dirk will use
   # the standard CA certificates supplied with the server.
-  ca-cert: file:///home/me/dirk/security/certificates/ca.crt
   # Note: Client certificates should include the client identity in Subject Alternative Names (SAN).
   # Dirk supports DNS names, IP addresses, and email addresses in SAN fields, with DNS names preferred.
   # Legacy certificates using only Common Name (CN) are still supported for backward compatibility.
+  ca-cert: file:///home/me/dirk/security/certificates/ca.crt
+  # reload-timeout defines the maximum time allowed for a certificate reload operation to complete.
+  # If a reload operation exceeds this duration, it will be cancelled. If not specified or set to 0,
+  # reload operations have no timeout. A reload will be triggered automatically at Dirk start up if
+  # certificates are expired. Alternatively, certificates can be reloaded on demand by sending a
+  # SIGHUP signal to Dirk's process. Note that only one reload operation can run at a time; concurrent
+  # reload attempts will be silently ignored while a reload is in progress.
+  reload-timeout: '10m'
 # storage-path is the path where information created by the slashing protection system is stored.  If not
 # supplied it will default to using the 'storage' directory in the user's home directory.
 storage-path: /home/me/dirk/protection

--- a/logging.go
+++ b/logging.go
@@ -26,7 +26,7 @@ import (
 // log.
 var log zerolog.Logger
 
-// initLogging initialises logging.
+// initLogging initializes logging.
 func initLogging() error {
 	// We set the global logging level to trace, because if the global log level is higher than the
 	// local log level the local level is ignored.  It is then overridden for each module.

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 		sig := <-sigCh
 		if sig == syscall.SIGHUP {
 			log.Info().Msg("Received SIGHUP; renewing certificates")
-			certManagerSvc.TryReloadCertificate()
+			certManagerSvc.TryReloadCertificate(ctx)
 			continue
 		}
 		if sig == syscall.SIGINT || sig == syscall.SIGTERM || sig == os.Interrupt || sig == os.Kill {

--- a/main.go
+++ b/main.go
@@ -820,7 +820,7 @@ func obtainCA(ctx context.Context,
 	error,
 ) {
 	if viper.GetString("certificates.ca-cert") == "" {
-		// CA certificate is optional - return empty slice to use standard CA certificates
+		// CA certificate is optional - return empty slice to use standard CA certificates.
 		log.Warn().Msg("No CA certificate specified; using standard CA certificates")
 		return []byte{}, nil
 	}

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.2.1-rc.1"
+var ReleaseVersion = "1.2.1-rc.2"
 
 // initSystemComponents initializes profiling, tracing, runtime settings, and BLS.
 func initSystemComponents(ctx context.Context, majordomoSvc majordomo.Service) error {
@@ -820,7 +820,9 @@ func obtainCA(ctx context.Context,
 	error,
 ) {
 	if viper.GetString("certificates.ca-cert") == "" {
-		return nil, errors.New("no CA certificate specified")
+		// CA certificate is optional - return empty slice to use standard CA certificates
+		log.Warn().Msg("No CA certificate specified; using standard CA certificates")
+		return []byte{}, nil
 	}
 	caPEMBlock, err := majordomoSvc.Fetch(ctx, viper.GetString("certificates.ca-cert"))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -268,7 +268,7 @@ func fetchConfig() (bool, error) {
 	return false, nil
 }
 
-// initProfiling initialises the profiling server.
+// initProfiling initializes the profiling server.
 func initProfiling() {
 	profileAddress := viper.GetString("profile-address")
 	if profileAddress != "" {
@@ -402,7 +402,7 @@ func logModules() {
 	}
 }
 
-// initRules initialises a rules service.
+// initRules initializes a rules service.
 func initRules(ctx context.Context) (rules.Service, error) {
 	return standardrules.New(ctx,
 		standardrules.WithLogLevel(util.LogLevel("rules")),

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ import (
 	standardrules "github.com/attestantio/dirk/rules/standard"
 	standardaccountmanager "github.com/attestantio/dirk/services/accountmanager/standard"
 	grpcapi "github.com/attestantio/dirk/services/api/grpc"
+	"github.com/attestantio/dirk/services/certmanager"
+	standardcertmanager "github.com/attestantio/dirk/services/certmanager/standard"
 	"github.com/attestantio/dirk/services/checker"
 	staticchecker "github.com/attestantio/dirk/services/checker/static"
 	"github.com/attestantio/dirk/services/fetcher"
@@ -71,7 +73,7 @@ import (
 )
 
 // ReleaseVersion is the release version for the code.
-var ReleaseVersion = "1.2.1-rc.2"
+var ReleaseVersion = "1.2.1-rc.1"
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -131,9 +133,15 @@ func main() {
 	setRelease(ctx, ReleaseVersion)
 	setReady(ctx, false)
 
-	err = startServices(ctx, majordomoSvc, monitor)
+	certManagerSvc, err := startCertManager(ctx, majordomoSvc)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to initialise services")
+		log.Error().Err(err).Msg("Failed to set up certmanager service")
+		return
+	}
+
+	err = startServices(ctx, majordomoSvc, certManagerSvc, monitor)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to initialize services")
 		return
 	}
 	setReady(ctx, true)
@@ -142,9 +150,14 @@ func main() {
 
 	// Wait for signal.
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, os.Interrupt)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP, os.Interrupt)
 	for {
 		sig := <-sigCh
+		if sig == syscall.SIGHUP {
+			log.Info().Msg("Received SIGHUP; renewing certificates")
+			certManagerSvc.TryReloadCertificate()
+			continue
+		}
 		if sig == syscall.SIGINT || sig == syscall.SIGTERM || sig == os.Interrupt || sig == os.Kill {
 			cancel()
 			break
@@ -206,6 +219,7 @@ func fetchConfig() (bool, error) {
 	viper.SetDefault("logging.timestamp.format", "2006-01-02T15:04:05.000Z07:00")
 	viper.SetDefault("storage-path", "storage")
 	viper.SetDefault("process.generation-timeout", 70*time.Second)
+	viper.SetDefault("certificates.reload-timeout", 10*time.Minute)
 
 	if err := viper.ReadInConfig(); err != nil {
 		switch {
@@ -287,7 +301,7 @@ func runCommands(ctx context.Context, majordomoSvc majordomo.Service) (bool, int
 	return false, 0
 }
 
-func startServices(ctx context.Context, majordomoSvc majordomo.Service, monitor metrics.Service) error {
+func startServices(ctx context.Context, majordomoSvc majordomo.Service, certManagerSvc certmanager.Service, monitor metrics.Service) error {
 	stores, err := initStores(ctx, majordomoSvc)
 	if err != nil {
 		return err
@@ -321,7 +335,7 @@ func startServices(ctx context.Context, majordomoSvc majordomo.Service, monitor 
 		return errors.Wrap(err, "failed to set up ruler service")
 	}
 
-	_, err = startGrpcServer(ctx, monitor, majordomoSvc, stores, unlockerSvc, checkerSvc, fetcherSvc, rulerSvc)
+	_, err = startGrpcServer(ctx, monitor, majordomoSvc, stores, unlockerSvc, checkerSvc, fetcherSvc, rulerSvc, certManagerSvc)
 	if err != nil {
 		return err
 	}
@@ -490,6 +504,16 @@ func startRuler(ctx context.Context, lockerSvc locker.Service, monitor metrics.S
 	)
 }
 
+func startCertManager(ctx context.Context, majordomoSvc majordomo.Service) (certmanager.Service, error) {
+	return standardcertmanager.New(ctx,
+		standardcertmanager.WithLogLevel(util.LogLevel("certmanager")),
+		standardcertmanager.WithMajordomo(majordomoSvc),
+		standardcertmanager.WithCertPEMURI(viper.GetString("certificates.server-cert")),
+		standardcertmanager.WithCertKeyURI(viper.GetString("certificates.server-key")),
+		standardcertmanager.WithReloadTimeout(viper.GetDuration("certificates.reload-timeout")),
+	)
+}
+
 func startPeers(ctx context.Context, monitor metrics.Service) (peers.Service, error) {
 	// Keys are strings.
 	peersInfo := viper.GetStringMapString("peers")
@@ -567,8 +591,7 @@ func startSigner(ctx context.Context,
 
 func startSender(ctx context.Context,
 	monitor metrics.Service,
-	certPEMBlock []byte,
-	keyPEMBlock []byte,
+	certManagerSvc certmanager.Service,
 	caPEMBlock []byte,
 ) (
 	sender.Service,
@@ -583,8 +606,7 @@ func startSender(ctx context.Context,
 		sendergrpc.WithLogLevel(util.LogLevel("sender")),
 		sendergrpc.WithMonitor(senderMonitor),
 		sendergrpc.WithName(viper.GetString("server.name")),
-		sendergrpc.WithServerCert(certPEMBlock),
-		sendergrpc.WithServerKey(keyPEMBlock),
+		sendergrpc.WithCertManager(certManagerSvc),
 		sendergrpc.WithCACert(caPEMBlock),
 	)
 	if err != nil {
@@ -603,14 +625,13 @@ func startProcess(ctx context.Context,
 	checkerSvc checker.Service,
 	fetcherSvc fetcher.Service,
 	peersSvc peers.Service,
-	certPEMBlock []byte,
-	keyPEMBlock []byte,
+	certManagerSvc certmanager.Service,
 	caPEMBlock []byte,
 ) (
 	process.Service,
 	error,
 ) {
-	sender, err := startSender(ctx, monitor, certPEMBlock, keyPEMBlock, caPEMBlock)
+	sender, err := startSender(ctx, monitor, certManagerSvc, caPEMBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -659,6 +680,7 @@ func startGrpcServer(ctx context.Context,
 	checkerSvc checker.Service,
 	fetcherSvc fetcher.Service,
 	rulerSvc ruler.Service,
+	certManagerSvc certmanager.Service,
 ) (
 	*grpcapi.Service,
 	error,
@@ -685,7 +707,7 @@ func startGrpcServer(ctx context.Context,
 		return nil, errors.Wrap(err, "failed to obtain server ID")
 	}
 
-	certPEMBlock, keyPEMBlock, caPEMBlock, err := obtainCerts(ctx, majordomoSvc)
+	caPEMBlock, err := obtainCA(ctx, majordomoSvc)
 	if err != nil {
 		return nil, err
 	}
@@ -699,8 +721,7 @@ func startGrpcServer(ctx context.Context,
 		checkerSvc,
 		fetcherSvc,
 		peersSvc,
-		certPEMBlock,
-		keyPEMBlock,
+		certManagerSvc,
 		caPEMBlock,
 	)
 	if err != nil {
@@ -755,8 +776,7 @@ func startGrpcServer(ctx context.Context,
 		grpcapi.WithPeers(peersSvc),
 		grpcapi.WithName(viper.GetString("server.name")),
 		grpcapi.WithID(serverID),
-		grpcapi.WithServerCert(certPEMBlock),
-		grpcapi.WithServerKey(keyPEMBlock),
+		grpcapi.WithCertManager(certManagerSvc),
 		grpcapi.WithCACert(caPEMBlock),
 		grpcapi.WithListenAddress(viper.GetString("server.listen-address")),
 	)
@@ -767,28 +787,18 @@ func startGrpcServer(ctx context.Context,
 	return svc, nil
 }
 
-func obtainCerts(ctx context.Context,
+func obtainCA(ctx context.Context,
 	majordomoSvc majordomo.Service,
 ) (
 	[]byte,
-	[]byte,
-	[]byte,
 	error,
 ) {
-	certPEMBlock, err := majordomoSvc.Fetch(ctx, viper.GetString("certificates.server-cert"))
+	if viper.GetString("certificates.ca-cert") == "" {
+		return nil, errors.New("no CA certificate specified")
+	}
+	caPEMBlock, err := majordomoSvc.Fetch(ctx, viper.GetString("certificates.ca-cert"))
 	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, fmt.Sprintf("failed to obtain server certificate from %s", viper.GetString("certificates.server-cert")))
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to obtain CA certificate from %s", viper.GetString("certificates.ca-cert")))
 	}
-	keyPEMBlock, err := majordomoSvc.Fetch(ctx, viper.GetString("certificates.server-key"))
-	if err != nil {
-		return nil, nil, nil, errors.Wrap(err, fmt.Sprintf("failed to obtain server key from %s", viper.GetString("certificates.server-key")))
-	}
-	var caPEMBlock []byte
-	if viper.GetString("certificates.ca-cert") != "" {
-		caPEMBlock, err = majordomoSvc.Fetch(ctx, viper.GetString("certificates.ca-cert"))
-		if err != nil {
-			return nil, nil, nil, errors.Wrap(err, fmt.Sprintf("failed to obtain CA certificate from %s", viper.GetString("certificates.ca-cert")))
-		}
-	}
-	return certPEMBlock, keyPEMBlock, caPEMBlock, nil
+	return caPEMBlock, nil
 }

--- a/services/api/grpc/handlers/receiver/grpc_test.go
+++ b/services/api/grpc/handlers/receiver/grpc_test.go
@@ -314,6 +314,10 @@ func createServer(ctx context.Context, name string, id uint64, port uint32, base
 		standardcertmanager.WithCertPEMURI(certPEMURI),
 		standardcertmanager.WithCertKeyURI(certKeyURI),
 	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create cert manager")
+	}
+
 	caPEMBlock, err := os.ReadFile(filepath.Join(base, "ca.crt"))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to obtain CA certificate")

--- a/services/api/grpc/handlers/receiver/grpc_test.go
+++ b/services/api/grpc/handlers/receiver/grpc_test.go
@@ -28,21 +28,28 @@ import (
 	mockrules "github.com/attestantio/dirk/rules/mock"
 	mockaccountmanager "github.com/attestantio/dirk/services/accountmanager/mock"
 	grpcapi "github.com/attestantio/dirk/services/api/grpc"
+	"github.com/attestantio/dirk/services/certmanager"
 	standardcertmanager "github.com/attestantio/dirk/services/certmanager/standard"
+	"github.com/attestantio/dirk/services/checker"
 	mockchecker "github.com/attestantio/dirk/services/checker/mock"
+	"github.com/attestantio/dirk/services/fetcher"
 	memfetcher "github.com/attestantio/dirk/services/fetcher/mem"
 	mocklister "github.com/attestantio/dirk/services/lister/mock"
 	standardlister "github.com/attestantio/dirk/services/lister/standard"
+	"github.com/attestantio/dirk/services/locker"
 	syncmaplocker "github.com/attestantio/dirk/services/locker/syncmap"
+	"github.com/attestantio/dirk/services/peers"
 	staticpeers "github.com/attestantio/dirk/services/peers/static"
 	"github.com/attestantio/dirk/services/process"
 	standardprocess "github.com/attestantio/dirk/services/process/standard"
+	"github.com/attestantio/dirk/services/ruler"
 	goruler "github.com/attestantio/dirk/services/ruler/golang"
 	"github.com/attestantio/dirk/services/sender"
 	grpcsender "github.com/attestantio/dirk/services/sender/grpc"
 	mocksender "github.com/attestantio/dirk/services/sender/mock"
 	mocksigner "github.com/attestantio/dirk/services/signer/mock"
 	standardsigner "github.com/attestantio/dirk/services/signer/standard"
+	"github.com/attestantio/dirk/services/unlocker"
 	localunlocker "github.com/attestantio/dirk/services/unlocker/local"
 	mockwalletmanager "github.com/attestantio/dirk/services/walletmanager/mock"
 	"github.com/attestantio/dirk/testing/mock"
@@ -54,6 +61,7 @@ import (
 	distributed "github.com/wealdtech/go-eth2-wallet-distributed"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 	e2wtypes "github.com/wealdtech/go-eth2-wallet-types/v2"
+	"github.com/wealdtech/go-majordomo"
 )
 
 func TestAbort(t *testing.T) {
@@ -207,20 +215,8 @@ func createServers(ctx context.Context) (string, []*core.Endpoint, []*grpcapi.Se
 	return base, endpoints, grpcdServices, nil
 }
 
-func createServer(ctx context.Context, name string, id uint64, port uint32, base string) (*grpcapi.Service, error) {
-	majordomo, err := util.InitMajordomo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	unlocker, err := localunlocker.New(ctx,
-		localunlocker.WithAccountPassphrases([]string{}))
-	if err != nil {
-		return nil, err
-	}
-	checker, err := mockchecker.New(zerolog.Disabled)
-	if err != nil {
-		return nil, err
-	}
+// createTestStoresAndWallet creates filesystem stores and a test wallet for the test server.
+func createTestStoresAndWallet(ctx context.Context, majordomo majordomo.Service, base, name string) ([]e2wtypes.Store, error) {
 	stores, err := core.InitStores(ctx, majordomo, []*core.Store{
 		{
 			Name:     "Local",
@@ -237,6 +233,31 @@ func createServer(ctx context.Context, name string, id uint64, port uint32, base
 		return nil, err
 	}
 	if err := testWallet.(e2wtypes.WalletLocker).Unlock(ctx, nil); err != nil {
+		return nil, err
+	}
+
+	return stores, nil
+}
+
+// basicTestServices bundles the core test services to reduce argument lists.
+type basicTestServices struct {
+	unlocker unlocker.Service
+	checker  checker.Service
+	fetcher  fetcher.Service
+	locker   locker.Service
+	ruler    ruler.Service
+}
+
+// createBasicTestServices creates the basic services needed for testing.
+func createBasicTestServices(ctx context.Context, stores []e2wtypes.Store) (*basicTestServices, error) {
+	unlocker, err := localunlocker.New(ctx,
+		localunlocker.WithAccountPassphrases([]string{}))
+	if err != nil {
+		return nil, err
+	}
+
+	checker, err := mockchecker.New(zerolog.Disabled)
+	if err != nil {
 		return nil, err
 	}
 
@@ -260,51 +281,27 @@ func createServer(ctx context.Context, name string, id uint64, port uint32, base
 		return nil, err
 	}
 
-	lister, err := standardlister.New(ctx,
-		standardlister.WithLogLevel(zerolog.Disabled),
-		standardlister.WithFetcher(fetcher),
-		standardlister.WithChecker(checker),
-		standardlister.WithRuler(ruler))
-	if err != nil {
-		return nil, err
-	}
+	return &basicTestServices{
+		unlocker: unlocker,
+		checker:  checker,
+		fetcher:  fetcher,
+		locker:   locker,
+		ruler:    ruler,
+	}, nil
+}
 
-	peers, err := staticpeers.New(ctx,
+// createTestPeers creates static peers for testing.
+func createTestPeers(ctx context.Context) (peers.Service, error) {
+	return staticpeers.New(ctx,
 		staticpeers.WithPeers(map[uint64]string{
 			1: "signer-test01:8881",
 			2: "signer-test02:8882",
 			3: "signer-test03:8883",
 		}))
-	if err != nil {
-		return nil, err
-	}
+}
 
-	// Set up the signer.
-	signer, err := standardsigner.New(ctx,
-		standardsigner.WithLogLevel(zerolog.Disabled),
-		standardsigner.WithUnlocker(unlocker),
-		standardsigner.WithChecker(checker),
-		standardsigner.WithFetcher(fetcher),
-		standardsigner.WithRuler(ruler))
-	if err != nil {
-		return nil, err
-	}
-
-	process, err := standardprocess.New(ctx,
-		standardprocess.WithChecker(checker),
-		standardprocess.WithGenerationPassphrase([]byte("secret")),
-		standardprocess.WithID(id),
-		standardprocess.WithPeers(peers),
-		standardprocess.WithSender(mocksender.New(id)),
-		standardprocess.WithFetcher(fetcher),
-		standardprocess.WithStores(stores),
-		standardprocess.WithUnlocker(unlocker),
-	)
-	if err != nil {
-		return nil, err
-	}
-	mock.Processes[id] = process
-
+// createTestCertManager creates a certificate manager for testing.
+func createTestCertManager(ctx context.Context, majordomo majordomo.Service, base, name string) (certmanager.Service, []byte, error) {
 	certPEMURI := "file://" + filepath.Join(base, fmt.Sprintf("%s.crt", name))
 	certKeyURI := "file://" + filepath.Join(base, fmt.Sprintf("%s.key", name))
 
@@ -315,12 +312,76 @@ func createServer(ctx context.Context, name string, id uint64, port uint32, base
 		standardcertmanager.WithCertKeyURI(certKeyURI),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create cert manager")
+		return nil, nil, errors.Wrap(err, "failed to create cert manager")
 	}
 
 	caPEMBlock, err := os.ReadFile(filepath.Join(base, "ca.crt"))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain CA certificate")
+		return nil, nil, errors.Wrap(err, "failed to obtain CA certificate")
+	}
+
+	return certManager, caPEMBlock, nil
+}
+
+func createServer(ctx context.Context, name string, id uint64, port uint32, base string) (*grpcapi.Service, error) {
+	majordomo, err := util.InitMajordomo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	stores, err := createTestStoresAndWallet(ctx, majordomo, base, name)
+	if err != nil {
+		return nil, err
+	}
+
+	basicSvcs, err := createBasicTestServices(ctx, stores)
+	if err != nil {
+		return nil, err
+	}
+
+	lister, err := standardlister.New(ctx,
+		standardlister.WithLogLevel(zerolog.Disabled),
+		standardlister.WithFetcher(basicSvcs.fetcher),
+		standardlister.WithChecker(basicSvcs.checker),
+		standardlister.WithRuler(basicSvcs.ruler))
+	if err != nil {
+		return nil, err
+	}
+
+	peers, err := createTestPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up the signer.
+	signer, err := standardsigner.New(ctx,
+		standardsigner.WithLogLevel(zerolog.Disabled),
+		standardsigner.WithUnlocker(basicSvcs.unlocker),
+		standardsigner.WithChecker(basicSvcs.checker),
+		standardsigner.WithFetcher(basicSvcs.fetcher),
+		standardsigner.WithRuler(basicSvcs.ruler))
+	if err != nil {
+		return nil, err
+	}
+
+	process, err := standardprocess.New(ctx,
+		standardprocess.WithChecker(basicSvcs.checker),
+		standardprocess.WithGenerationPassphrase([]byte("secret")),
+		standardprocess.WithID(id),
+		standardprocess.WithPeers(peers),
+		standardprocess.WithSender(mocksender.New(id)),
+		standardprocess.WithFetcher(basicSvcs.fetcher),
+		standardprocess.WithStores(stores),
+		standardprocess.WithUnlocker(basicSvcs.unlocker),
+	)
+	if err != nil {
+		return nil, err
+	}
+	mock.Processes[id] = process
+
+	certManager, caPEMBlock, err := createTestCertManager(ctx, majordomo, base, name)
+	if err != nil {
+		return nil, err
 	}
 
 	serverSvc, err := grpcapi.New(ctx,

--- a/services/api/grpc/parameters.go
+++ b/services/api/grpc/parameters.go
@@ -144,13 +144,74 @@ func WithCACert(caCert []byte) Parameter {
 	})
 }
 
+// validateRequiredServices checks that all required service dependencies are present.
+func validateRequiredServices(p *parameters) error {
+	requiredServices := []struct {
+		service interface{}
+		name    string
+	}{
+		{p.signer, "signer"},
+		{p.lister, "lister"},
+		{p.process, "process"},
+		{p.walletManager, "wallet manager"},
+		{p.accountManager, "account manager"},
+		{p.peers, "peers"},
+		{p.certManager, "cert manager"},
+	}
+
+	for _, req := range requiredServices {
+		if req.service == nil {
+			return errors.New("no " + req.name + " specified")
+		}
+	}
+	return nil
+}
+
+// validateRequiredStrings checks that all required string parameters are present.
+func validateRequiredStrings(p *parameters) error {
+	requiredStrings := []struct {
+		value string
+		name  string
+	}{
+		{p.name, "name"},
+		{p.listenAddress, "listen address"},
+	}
+
+	for _, req := range requiredStrings {
+		if req.value == "" {
+			return errors.New("no " + req.name + " specified")
+		}
+	}
+	return nil
+}
+
+// validateRequiredNumbers checks that all required numeric parameters are present.
+func validateRequiredNumbers(p *parameters) error {
+	if p.id == 0 {
+		return errors.New("no ID specified")
+	}
+	return nil
+}
+
+// validateCertificate checks that the certificate manager has a valid certificate.
+func validateCertificate(certManager certmanager.Service) error {
+	cert, err := certManager.GetCertificate(nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to get server certificate")
+	}
+	if len(cert.Certificate) == 0 {
+		return errors.New("no server certificate specified")
+	}
+	return nil
+}
+
 // parseAndCheckParameters parses and checks parameters to ensure that mandatory parameters are present and correct.
 func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 	parameters := parameters{
 		logLevel: zerolog.GlobalLevel(),
 	}
 	for _, p := range params {
-		if params != nil {
+		if p != nil {
 			p.apply(&parameters)
 		}
 	}
@@ -159,42 +220,21 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		// Use no-op monitor.
 		parameters.monitor = &noopMonitor{}
 	}
-	if parameters.signer == nil {
-		return nil, errors.New("no signer specified")
+
+	if err := validateRequiredServices(&parameters); err != nil {
+		return nil, err
 	}
-	if parameters.lister == nil {
-		return nil, errors.New("no lister specified")
+
+	if err := validateRequiredStrings(&parameters); err != nil {
+		return nil, err
 	}
-	if parameters.process == nil {
-		return nil, errors.New("no process specified")
+
+	if err := validateRequiredNumbers(&parameters); err != nil {
+		return nil, err
 	}
-	if parameters.walletManager == nil {
-		return nil, errors.New("no wallet manager specified")
-	}
-	if parameters.accountManager == nil {
-		return nil, errors.New("no account manager specified")
-	}
-	if parameters.peers == nil {
-		return nil, errors.New("no peers specified")
-	}
-	if parameters.name == "" {
-		return nil, errors.New("no name specified")
-	}
-	if parameters.id == 0 {
-		return nil, errors.New("no ID specified")
-	}
-	if parameters.listenAddress == "" {
-		return nil, errors.New("no listen address specified")
-	}
-	if parameters.certManager == nil {
-		return nil, errors.New("no cert manager specified")
-	}
-	cert, err := parameters.certManager.GetCertificate(nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get server certificate")
-	}
-	if len(cert.Certificate) == 0 {
-		return nil, errors.New("no server certificate specified")
+
+	if err := validateCertificate(parameters.certManager); err != nil {
+		return nil, err
 	}
 
 	return &parameters, nil

--- a/services/api/grpc/service.go
+++ b/services/api/grpc/service.go
@@ -25,6 +25,7 @@ import (
 	signerhandler "github.com/attestantio/dirk/services/api/grpc/handlers/signer"
 	walletmanagerhandler "github.com/attestantio/dirk/services/api/grpc/handlers/walletmanager"
 	"github.com/attestantio/dirk/services/api/grpc/interceptors"
+	"github.com/attestantio/dirk/services/certmanager"
 	"github.com/attestantio/dirk/services/metrics"
 	"github.com/attestantio/dirk/util/loggers"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -66,7 +67,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		monitor: parameters.monitor,
 	}
 
-	if err := s.createServer(parameters.name, parameters.serverCert, parameters.serverKey, parameters.caCert); err != nil {
+	if err := s.createServer(parameters.name, parameters.certManager, parameters.caCert); err != nil {
 		return nil, errors.Wrap(err, "failed to create API server")
 	}
 
@@ -118,7 +119,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 	pb.RegisterDKGServer(s.grpcServer, receiverHandler)
 
-	err = s.serve(ctx, parameters.listenAddress)
+	err = s.serve(parameters.listenAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start API server")
 	}
@@ -133,7 +134,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 }
 
 // createServer creates the GRPC server.
-func (s *Service) createServer(name string, certPEMBlock []byte, keyPEMBlock []byte, caPEMBlock []byte) error {
+func (s *Service) createServer(name string, certManager certmanager.Service, caPEMBlock []byte) error {
 	grpclog.SetLoggerV2(loggers.NewGRPCLoggerV2(log.With().Str("service", "grpc").Logger()))
 
 	grpcOpts := []grpc.ServerOption{
@@ -151,11 +152,6 @@ func (s *Service) createServer(name string, certPEMBlock []byte, keyPEMBlock []b
 		return errors.New("no server name provided; cannot proceed")
 	}
 
-	serverCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return errors.Wrap(err, "failed to load server keypair")
-	}
-
 	certPool := x509.NewCertPool()
 	if len(caPEMBlock) > 0 {
 		// Read in the certificate authority certificate; this is required to validate client certificates on incoming connections.
@@ -165,10 +161,10 @@ func (s *Service) createServer(name string, certPEMBlock []byte, keyPEMBlock []b
 	}
 
 	serverCreds := credentials.NewTLS(&tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{serverCert},
-		ClientCAs:    certPool,
-		MinVersion:   tls.VersionTLS13,
+		ClientAuth:     tls.RequireAndVerifyClientCert,
+		GetCertificate: certManager.GetCertificate,
+		ClientCAs:      certPool,
+		MinVersion:     tls.VersionTLS13,
 	})
 	grpcOpts = append(grpcOpts, grpc.Creds(serverCreds))
 	s.grpcServer = grpc.NewServer(grpcOpts...)
@@ -177,16 +173,15 @@ func (s *Service) createServer(name string, certPEMBlock []byte, keyPEMBlock []b
 }
 
 // Serve serves the GRPC server.
-func (s *Service) serve(ctx context.Context, listenAddress string) error {
-	var lc net.ListenConfig
-	listener, err := lc.Listen(ctx, "tcp", listenAddress)
+func (s *Service) serve(listenAddress string) error {
+	conn, err := net.Listen("tcp", listenAddress)
 	if err != nil {
 		return err
 	}
 	log.Info().Str("address", listenAddress).Msg("Listening")
 
 	go func() {
-		if err := s.grpcServer.Serve(listener); err != nil {
+		if err := s.grpcServer.Serve(conn); err != nil {
 			log.Error().Err(err).Msg("Could not start GRPC server")
 		}
 	}()

--- a/services/api/grpc/service.go
+++ b/services/api/grpc/service.go
@@ -119,7 +119,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 	}
 	pb.RegisterDKGServer(s.grpcServer, receiverHandler)
 
-	err = s.serve(parameters.listenAddress)
+	err = s.serve(ctx, parameters.listenAddress)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start API server")
 	}
@@ -173,15 +173,16 @@ func (s *Service) createServer(name string, certManager certmanager.Service, caP
 }
 
 // Serve serves the GRPC server.
-func (s *Service) serve(listenAddress string) error {
-	conn, err := net.Listen("tcp", listenAddress)
+func (s *Service) serve(ctx context.Context, listenAddress string) error {
+	var lc net.ListenConfig
+	listener, err := lc.Listen(ctx, "tcp", listenAddress)
 	if err != nil {
 		return err
 	}
 	log.Info().Str("address", listenAddress).Msg("Listening")
 
 	go func() {
-		if err := s.grpcServer.Serve(conn); err != nil {
+		if err := s.grpcServer.Serve(listener); err != nil {
 			log.Error().Err(err).Msg("Could not start GRPC server")
 		}
 	}()

--- a/services/certmanager/service.go
+++ b/services/certmanager/service.go
@@ -21,7 +21,7 @@ import (
 // Service is the tls certificate manager service.
 type Service interface {
 	// GetCertificate gets the certificate, reloading it if current certificate is expired.
-	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+	GetCertificate(info *tls.ClientHelloInfo) (*tls.Certificate, error)
 
 	// TryReloadCertificate tries to reload the certificate.
 	TryReloadCertificate(ctx context.Context)

--- a/services/certmanager/service.go
+++ b/services/certmanager/service.go
@@ -13,7 +13,10 @@
 
 package certmanager
 
-import "crypto/tls"
+import (
+	"context"
+	"crypto/tls"
+)
 
 // Service is the tls certificate manager service.
 type Service interface {
@@ -21,5 +24,5 @@ type Service interface {
 	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
 
 	// TryReloadCertificate tries to reload the certificate.
-	TryReloadCertificate()
+	TryReloadCertificate(ctx context.Context)
 }

--- a/services/certmanager/service.go
+++ b/services/certmanager/service.go
@@ -1,0 +1,25 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certmanager
+
+import "crypto/tls"
+
+// Service is the tls certificate manager service.
+type Service interface {
+	// GetCertificate gets the certificate, reloading it if current certificate is expired.
+	GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)
+
+	// TryReloadCertificate tries to reload the certificate.
+	TryReloadCertificate()
+}

--- a/services/certmanager/standard/parameters.go
+++ b/services/certmanager/standard/parameters.go
@@ -81,7 +81,7 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		logLevel: zerolog.GlobalLevel(),
 	}
 	for _, p := range params {
-		if params != nil {
+		if p != nil {
 			p.apply(&parameters)
 		}
 	}

--- a/services/certmanager/standard/parameters.go
+++ b/services/certmanager/standard/parameters.go
@@ -16,17 +16,17 @@ package standard
 import (
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/wealdtech/go-majordomo"
 )
 
 type parameters struct {
-	logLevel       zerolog.Level
-	majordomo      majordomo.Service
-	reloadThreshold time.Duration
-	reloadTimeout  time.Duration
-	certPEMURI     string
-	certKeyURI     string
+	logLevel      zerolog.Level
+	majordomo     majordomo.Service
+	reloadTimeout time.Duration
+	certPEMURI    string
+	certKeyURI    string
 }
 
 // Parameter is the interface for service parameters.
@@ -84,6 +84,16 @@ func parseAndCheckParameters(params ...Parameter) (*parameters, error) {
 		if params != nil {
 			p.apply(&parameters)
 		}
+	}
+
+	if parameters.majordomo == nil {
+		return nil, errors.New("no majordomo specified")
+	}
+	if parameters.certPEMURI == "" {
+		return nil, errors.New("no cert PEM URI specified")
+	}
+	if parameters.certKeyURI == "" {
+		return nil, errors.New("no cert key URI specified")
 	}
 
 	return &parameters, nil

--- a/services/certmanager/standard/service.go
+++ b/services/certmanager/standard/service.go
@@ -34,7 +34,7 @@ type Service struct {
 	certKeyURI    string
 
 	lastReloadAttemptTime time.Time
-	currentCertMutext     sync.RWMutex
+	currentCertMutex      sync.RWMutex
 	currentCert           atomic.Pointer[tls.Certificate]
 }
 
@@ -94,11 +94,11 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 
 // TryReloadCertificate tries to reload the certificate. Can be called asynchronously and on demand.
 func (s *Service) TryReloadCertificate(ctx context.Context) {
-	if !s.currentCertMutext.TryLock() {
+	if !s.currentCertMutex.TryLock() {
 		// Certificate is already being reloaded; do nothing.
 		return
 	}
-	defer s.currentCertMutext.Unlock()
+	defer s.currentCertMutex.Unlock()
 
 	s.lastReloadAttemptTime = time.Now()
 

--- a/services/certmanager/standard/service.go
+++ b/services/certmanager/standard/service.go
@@ -1,0 +1,183 @@
+// Copyright © 2025 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	zerologger "github.com/rs/zerolog/log"
+	"github.com/wealdtech/go-majordomo"
+)
+
+type Service struct {
+	ctx           context.Context
+	majordomo     majordomo.Service
+	reloadTimeout time.Duration
+	certPEMURI    string
+	certKeyURI    string
+
+	lastReloadAttemptTime time.Time
+	currentCertMutext     sync.RWMutex
+	currentCert           atomic.Pointer[tls.Certificate]
+}
+
+// module-wide log.
+var log zerolog.Logger
+
+// New creates a new cert manager service.
+func New(ctx context.Context, params ...Parameter) (*Service, error) {
+	parameters, err := parseAndCheckParameters(params...)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with parameters")
+	}
+
+	// Set logging.
+	log = zerologger.With().Str("service", "certmanager").Str("impl", "standard").Logger()
+	if parameters.logLevel != log.GetLevel() {
+		log = log.Level(parameters.logLevel)
+	}
+
+	// Load the certificates immediately.
+	certPEMBlock, err := parameters.majordomo.Fetch(ctx, parameters.certPEMURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to obtain server certificate")
+	}
+	certKeyBlock, err := parameters.majordomo.Fetch(ctx, parameters.certKeyURI)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to obtain server key")
+	}
+
+	// Initialise the certificate pair.
+	serverCert, err := tls.X509KeyPair(certPEMBlock, certKeyBlock)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load certificate pair")
+	}
+	if len(serverCert.Certificate) == 0 {
+		return nil, errors.New("certificate file does not contain a certificate")
+	}
+	cert, err := x509.ParseCertificate(serverCert.Certificate[0])
+	if err != nil || cert == nil {
+		return nil, errors.Wrap(err, "failed to parse server certificate")
+	}
+	if cert.NotAfter.Before(time.Now()) {
+		log.Warn().Time("expiry", cert.NotAfter).Msg("Server certificate expired")
+	}
+
+	log.Info().Str("issued_to", cert.Subject.CommonName).Str("issued_by", cert.Issuer.CommonName).Time("valid_until", cert.NotAfter).Msg("Server certificate loaded")
+
+	out := &Service{
+		ctx:           ctx,
+		majordomo:     parameters.majordomo,
+		certPEMURI:    parameters.certPEMURI,
+		certKeyURI:    parameters.certKeyURI,
+		reloadTimeout: parameters.reloadTimeout,
+	}
+	out.currentCert.Store(&serverCert)
+	return out, nil
+}
+
+// TryReloadCertificate tries to reload the certificate. Can be called asynchronously and on demand.
+func (s *Service) TryReloadCertificate() {
+	if !s.currentCertMutext.TryLock() {
+		// Certificate is already being reloaded; do nothing.
+		return
+	}
+	defer s.currentCertMutext.Unlock()
+
+	s.lastReloadAttemptTime = time.Now()
+
+	ctx := s.ctx
+	if s.reloadTimeout > 0 {
+		var cancel context.CancelFunc
+		// Give up on the reload if it takes longer than the reload timeout.
+		ctx, cancel = context.WithDeadline(s.ctx, s.lastReloadAttemptTime.Add(s.reloadTimeout))
+		defer cancel()
+	}
+
+	certPEMBlock, err := s.majordomo.Fetch(ctx, s.certPEMURI)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to obtain server certificate during reload")
+		return
+	}
+	certKeyBlock, err := s.majordomo.Fetch(ctx, s.certKeyURI)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to obtain server key during reload")
+		return
+	}
+
+	// Load the certificate pair.
+	serverCert, err := tls.X509KeyPair(certPEMBlock, certKeyBlock)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to load certificate pair during reload")
+		return
+	}
+	if len(serverCert.Certificate) == 0 {
+		log.Warn().Msg("Certificate file does not contain a certificate")
+		return
+	}
+	cert, err := x509.ParseCertificate(serverCert.Certificate[0])
+	if err != nil || cert == nil {
+		log.Warn().Msg("Failed to parse certificate")
+		return
+	}
+
+	newExpiry := cert.NotAfter
+	if newExpiry.Before(time.Now()) {
+		log.Warn().
+			Str("issued_to", cert.Subject.CommonName).
+			Str("issued_by", cert.Issuer.CommonName).
+			Time("expiry", newExpiry).
+			Msg("Server certificate expired, send SIGHUP to reload it.")
+		return
+	}
+
+	log.Info().Str("issued_to", cert.Subject.CommonName).Str("issued_by", cert.Issuer.CommonName).Time("valid_until", newExpiry).Msg("Server certificate reloaded successfully")
+
+	s.currentCert.Store(&serverCert)
+}
+
+// GetCertificate returns the certificate.
+func (s *Service) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	currentCert := s.currentCert.Load()
+	cert, err := x509.ParseCertificate(currentCert.Certificate[0])
+	if err != nil || cert == nil {
+		log.Warn().Msg("Failed to parse certificate")
+		return nil, errors.New("Could not parse certificate")
+	}
+
+	// Do we want to reload automatically the certificate if it is expired?
+	// If not, shall we return an error or just use the existing certificate?
+	// The code block below should be removed if we don't want to reload automatically the certificate if it is expired.
+	expiry := cert.NotAfter
+	if expiry.Before(time.Now()) {
+		log.Warn().
+			Str("issued_to", cert.Subject.CommonName).
+			Str("issued_by", cert.Issuer.CommonName).
+			Time("expiry", expiry).
+			Msg("Server certificate expired, reloading it...")
+		// Reload the certificate.
+		s.TryReloadCertificate()
+	}
+
+	// Use the existing certificate.
+	// It will use the expired certificate if it is not reloaded successfully.
+	return currentCert, nil
+}

--- a/services/certmanager/standard/service.go
+++ b/services/certmanager/standard/service.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		return nil, errors.Wrap(err, "failed to obtain server key")
 	}
 
-	// Initialise the certificate pair.
+	// initialize the certificate pair.
 	serverCert, err := tls.X509KeyPair(certPEMBlock, certKeyBlock)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load certificate pair")

--- a/services/sender/grpc/service.go
+++ b/services/sender/grpc/service.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/attestantio/dirk/core"
+	"github.com/attestantio/dirk/services/certmanager"
 	"github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/jackc/puddle"
 	"github.com/pkg/errors"
@@ -54,7 +55,7 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		log = log.Level(parameters.logLevel)
 	}
 
-	transportCredentials, err := composeCredentials(ctx, parameters.serverCert, parameters.serverKey, parameters.caCert)
+	transportCredentials, err := composeCredentials(ctx, parameters.certManager, parameters.caCert)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to compose client credentials")
 	}
@@ -201,15 +202,13 @@ func (s *Service) SendContribution(ctx context.Context, peer *core.Endpoint, acc
 	return resSecret, resVVec, nil
 }
 
-func composeCredentials(_ context.Context, certPEMBlock []byte, keyPEMBlock []byte, caPEMBlock []byte) (credentials.TransportCredentials, error) {
-	clientCert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to access client certificate/key")
-	}
+func composeCredentials(_ context.Context, certmanager certmanager.Service, caPEMBlock []byte) (credentials.TransportCredentials, error) {
 
 	tlsCfg := &tls.Config{
-		Certificates: []tls.Certificate{clientCert},
-		MinVersion:   tls.VersionTLS13,
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return certmanager.GetCertificate(nil)
+		},
+		MinVersion: tls.VersionTLS13,
 	}
 	if len(caPEMBlock) > 0 {
 		cp := x509.NewCertPool()

--- a/services/sender/grpc/service.go
+++ b/services/sender/grpc/service.go
@@ -203,7 +203,6 @@ func (s *Service) SendContribution(ctx context.Context, peer *core.Endpoint, acc
 }
 
 func composeCredentials(_ context.Context, certmanager certmanager.Service, caPEMBlock []byte) (credentials.TransportCredentials, error) {
-
 	tlsCfg := &tls.Config{
 		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			return certmanager.GetCertificate(nil)

--- a/testing/daemon/daemon_test.go
+++ b/testing/daemon/daemon_test.go
@@ -84,6 +84,7 @@ func TestCertReload(t *testing.T) {
 	err = resources.SetupCerts(certPath)
 	require.NoError(t, err)
 
+	// #nosec G404
 	port := uint32(12000 + rand.Intn(4000))
 	logCapture, path, services, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
 	require.NoError(t, err)

--- a/testing/daemon/daemon_test.go
+++ b/testing/daemon/daemon_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/attestantio/dirk/services/certmanager"
 	"github.com/attestantio/dirk/testing/daemon"
+	"github.com/attestantio/dirk/testing/resources"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,10 +34,15 @@ func TestDaemon(t *testing.T) {
 		t.Skip("test signer addresses not configured; skipping test")
 	}
 
+	// Set up certificates
+	certPath := t.TempDir()
+	err = resources.SetupCerts(certPath)
+	require.NoError(t, err)
+
 	ctx := context.Background()
 	// #nosec G404
 	port := uint32(12000 + rand.Intn(4000))
-	_, path, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
+	_, path, _, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
 	require.NoError(t, err)
 	os.RemoveAll(path)
 }
@@ -46,10 +53,15 @@ func TestCancelDaemon(t *testing.T) {
 		t.Skip("test signer addresses not configured; skipping test")
 	}
 
+	// Set up certificates
+	certPath := t.TempDir()
+	err = resources.SetupCerts(certPath)
+	require.NoError(t, err)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	// #nosec G404
 	port := uint32(12000 + rand.Intn(4000))
-	_, path, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
+	_, path, _, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
 	require.NoError(t, err)
 	defer os.RemoveAll(path)
 	require.True(t, endpointAlive(fmt.Sprintf("signer-test01:%d", port)))
@@ -59,6 +71,74 @@ func TestCancelDaemon(t *testing.T) {
 	require.False(t, endpointAlive(fmt.Sprintf("signer-test01:%d", port)))
 }
 
+func TestCertReload(t *testing.T) {
+	_, err := net.LookupIP("signer-test01")
+	if err != nil {
+		t.Skip("test signer addresses not configured; skipping test")
+	}
+
+	ctx := context.Background()
+
+	// Set up certificates
+	certPath := t.TempDir()
+	err = resources.SetupCerts(certPath)
+	require.NoError(t, err)
+
+	port := uint32(12000 + rand.Intn(4000))
+	logCapture, path, services, err := daemon.New(ctx, "", 1, port, map[uint64]string{1: fmt.Sprintf("signer-test01:%d", port)})
+	require.NoError(t, err)
+	defer os.RemoveAll(path)
+
+	for _, svc := range services {
+		if certManager, ok := svc.(certmanager.Service); ok {
+			require.NotNil(t, certManager)
+
+			// Get initial certificate via GetCertificate
+			cert1, err := certManager.GetCertificate(nil)
+			require.NoError(t, err)
+			require.NotNil(t, cert1)
+			require.NotEmpty(t, cert1.Certificate)
+
+			// Replace the certificate file on disk with a different one (use signer-test02's cert)
+			originalCertPath := resources.CertPaths[1]
+			originalKeyPath := resources.KeyPaths[1]
+
+			// Back up original cert data
+			originalCertData, err := os.ReadFile(originalCertPath)
+			require.NoError(t, err)
+			originalKeyData, err := os.ReadFile(originalKeyPath)
+			require.NoError(t, err)
+			defer func() {
+				// Restore original certificates
+				os.WriteFile(originalCertPath, originalCertData, 0600)
+				os.WriteFile(originalKeyPath, originalKeyData, 0600)
+			}()
+
+			// Write new certificate (from signer-test02)
+			err = os.WriteFile(originalCertPath, resources.SignerCerts[2], 0600)
+			require.NoError(t, err)
+			err = os.WriteFile(originalKeyPath, resources.SignerKeys[2], 0600)
+			require.NoError(t, err)
+
+			// Trigger reload
+			certManager.TryReloadCertificate()
+			logCapture.AssertHasEntry(t, "Server certificate reloaded successfully")
+			require.True(t, endpointAlive(fmt.Sprintf("signer-test01:%d", port)))
+
+			// Get new certificate and verify it changed
+			cert2, err := certManager.GetCertificate(nil)
+			require.NoError(t, err)
+			require.NotNil(t, cert2)
+			require.NotEmpty(t, cert2.Certificate)
+
+			// Verify the certificates are different by comparing raw bytes
+			require.NotEqual(t, cert1.Certificate[0], cert2.Certificate[0], "Certificate should have changed after reload")
+
+			return
+		}
+	}
+	require.Fail(t, "cert manager not found")
+}
 func endpointAlive(address string) bool {
 	conn, err := net.DialTimeout("tcp", address, 5*time.Second)
 	if err == nil {

--- a/testing/daemon/daemon_test.go
+++ b/testing/daemon/daemon_test.go
@@ -121,7 +121,7 @@ func TestCertReload(t *testing.T) {
 			require.NoError(t, err)
 
 			// Trigger reload
-			certManager.TryReloadCertificate()
+			certManager.TryReloadCertificate(context.Background())
 			logCapture.AssertHasEntry(t, "Server certificate reloaded successfully")
 			require.True(t, endpointAlive(fmt.Sprintf("signer-test01:%d", port)))
 

--- a/testing/resources/certs.go
+++ b/testing/resources/certs.go
@@ -14,6 +14,7 @@
 package resources
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -524,56 +525,35 @@ var SignerKeys = map[uint64][]byte{
 	5: SignerTest05Key,
 }
 
+var CertPaths map[uint64]string
+var KeyPaths map[uint64]string
+
 // SetupCerts sets up a number of certificates on-disk in the provided location.
 func SetupCerts(base string) error {
+	CertPaths = make(map[uint64]string)
+	KeyPaths = make(map[uint64]string)
+	for id := range SignerCerts {
+		CertPaths[id] = filepath.Join(base, fmt.Sprintf("signer-test%02d.crt", id))
+	}
+	for id := range SignerKeys {
+		KeyPaths[id] = filepath.Join(base, fmt.Sprintf("signer-test%02d.key", id))
+	}
+
 	if err := os.WriteFile(filepath.Join(base, "ca.crt"), CACrt, 0o600); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test01.crt"), SignerTest01Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test01.key"), SignerTest01Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test02.crt"), SignerTest02Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test02.key"), SignerTest02Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test03.crt"), SignerTest03Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test03.key"), SignerTest03Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test04.crt"), SignerTest04Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test04.key"), SignerTest04Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test05.crt"), SignerTest05Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "signer-test05.key"), SignerTest05Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "client-test01.crt"), ClientTest01Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "client-test01.key"), ClientTest01Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "client-test02.crt"), ClientTest02Crt, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "client-test02.key"), ClientTest02Key, 0o600); err != nil {
-		return err
-	}
-	if err := os.WriteFile(filepath.Join(base, "client-test03.crt"), ClientTest03Crt, 0o600); err != nil {
-		return err
+
+	for id := range SignerCerts {
+		if err := os.WriteFile(CertPaths[id], SignerCerts[id], 0o600); err != nil {
+			return err
+		}
 	}
 
-	return os.WriteFile(filepath.Join(base, "client-test03.key"), ClientTest03Key, 0o600)
+	for id := range SignerKeys {
+		if err := os.WriteFile(KeyPaths[id], SignerKeys[id], 0o600); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/tracing.go
+++ b/tracing.go
@@ -38,7 +38,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// initTracing initialises the tracing system.
+// initTracing initializes the tracing system.
 func initTracing(ctx context.Context, majordomoSvc majordomo.Service) error {
 	if viper.GetString("tracing.address") == "" {
 		log.Debug().Msg("No tracing endpoint supplied; tracing not enabled")


### PR DESCRIPTION
This PR provides an alternative implementation of #83 to support on-demand certificate reload on a SIGHUP signal. 

The PR's branch is based on #87, therefore it is suggested to merge that PR first and then update this PR's reference to point to master.

The `GetCertificate` function is designed to be a callback used by the Go standard library's tls.Config. This means it only runs when a client connects to the server and initiates a TLS handshake. Currently, a certificate reload is automatically attempted when `GetCertificate` is called if the current certificate is expired. We can keep this behavior or only allow a certificate reload after a SIGHUP.

Current tests are asserting the reloading behavior, but not Dirk's process reaction on a SIGHUP.