### PR TITLE
Add buildx-compatible multi-arch Docker build for amd64 and arm64

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,4 +21,15 @@ coverage.html
 # Local TODO
 TODO.md
 
+# VCS and editor metadata
+.git
+.gitignore
+.github
+.idea
+.vscode
+.DS_Store
+
+# Logs
+*.log
+
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
-FROM golang:1.25-trixie as builder
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS builder
 
 WORKDIR /app
+
+ARG BUILDARCH
+RUN <<-EOF
+    set -e
+    packages=""
+    case "$BUILDARCH" in
+        amd64) packages="$packages gcc-aarch64-linux-gnu g++-aarch64-linux-gnu" ;;
+        arm64) packages="$packages gcc-x86-64-linux-gnu g++-x86-64-linux-gnu" ;;
+        *) echo "unsupported build architecture: $BUILDARCH" >&2; exit 1 ;;
+    esac
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y $packages
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+EOF
 
 COPY go.mod go.sum ./
 
@@ -8,14 +23,26 @@ RUN go mod download
 
 COPY . .
 
-RUN go build
+ARG TARGETOS
+ARG TARGETARCH
+RUN <<-EOF
+    set -e
+    if [ "$BUILDARCH" = "$TARGETARCH" ]; then
+        export CC=gcc CXX=g++
+    else
+        case "$TARGETARCH" in
+            amd64) export CC=x86_64-linux-gnu-gcc CXX=x86_64-linux-gnu-g++ ;;
+            arm64) export CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++ ;;
+            *) echo "unsupported target architecture: $TARGETARCH" >&2; exit 1 ;;
+        esac
+    fi
+    CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH CC=$CC CXX=$CXX go build -o /app/dirk .
+EOF
 
-FROM debian:bookworm-slim
-
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM gcr.io/distroless/base-debian12:nonroot
 
 WORKDIR /app
 
-COPY --from=builder /app/dirk /app
+COPY --from=builder /app/dirk /app/dirk
 
 ENTRYPOINT ["/app/dirk"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN <<-EOF
     CGO_ENABLED=1 GOOS=$TARGETOS GOARCH=$TARGETARCH CC=$CC CXX=$CXX go build -o /app/dirk .
 EOF
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM debian:bookworm-slim
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt install -y ca-certificates && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
This PR updates the Docker build so the image can be built for both `linux/amd64` and `linux/arm64` with `docker buildx`.

This partially resolves #96.

## What changed
- build the Go builder stage on `$BUILDPLATFORM`
- select the appropriate C cross-compiler based on `BUILDARCH`/`TARGETARCH`
- keep the same-arch path on the native compiler
- keep the runtime image on `debian:bookworm-slim` so the PR does not introduce a breaking runtime-base change
- tighten `.dockerignore` so local binaries, VCS metadata, and editor noise are not sent in the Docker build context

## Scope note
This PR only addresses Dockerfile-level multi-arch compatibility.

The arm64/multi-arch behavior comes from the builder-stage and cross-compilation changes. The earlier distroless runtime switch has been reverted because it is an independent breaking change and should not be bundled into this PR.

I could not find the image publish automation in this repository, so this does not update the build-and-push path for the published Docker image. If publishing is handled externally, that external pipeline will still need to build and publish a multi-arch manifest for the arm64 image to appear publicly.

## Verification
- `docker buildx build --platform linux/amd64 --output type=cacheonly .`
- `docker buildx build --platform linux/arm64 --output type=cacheonly .`