### PR TITLE
Add epoch-0 and slot-0 slashing protection tests

### DIFF
--- a/rules/standard/signbeaconattestation_test.go
+++ b/rules/standard/signbeaconattestation_test.go
@@ -143,7 +143,7 @@ func TestSignBeaconAttestation(t *testing.T) {
 }
 
 // TestSignBeaconAttestationEpochZero tests slashing protection behavior
-// at epoch 0 (genesis), where the sentinel value -1 transitions to 0.
+// at epoch 0 (genesis), where no prior attestation state exists.
 func TestSignBeaconAttestationEpochZero(t *testing.T) {
 	ctx := context.Background()
 	base, err := os.MkdirTemp("", "")

--- a/rules/standard/signbeaconattestation_test.go
+++ b/rules/standard/signbeaconattestation_test.go
@@ -141,3 +141,88 @@ func TestSignBeaconAttestation(t *testing.T) {
 		})
 	}
 }
+
+// TestSignBeaconAttestationEpochZero tests slashing protection behavior
+// at epoch 0 (genesis), where the sentinel value -1 transitions to 0.
+func TestSignBeaconAttestationEpochZero(t *testing.T) {
+	ctx := context.Background()
+	base, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(base)
+	testRules, err := standardrules.New(ctx,
+		standardrules.WithStoragePath(base),
+	)
+	require.NoError(t, err)
+
+	// Tests are sequential; each builds on state left by the previous.
+	tests := []struct {
+		name     string
+		metadata *rules.ReqMetadata
+		req      *rules.SignBeaconAttestationData
+		res      rules.Result
+	}{
+		{
+			name:     "GenesisAttestation",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconAttestationData{
+				Domain: _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000"),
+				Source: &rules.Checkpoint{
+					Epoch: 0,
+				},
+				Target: &rules.Checkpoint{
+					Epoch: 0,
+				},
+			},
+			res: rules.APPROVED,
+		},
+		{
+			name:     "GenesisAttestationRetry",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconAttestationData{
+				Domain: _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000"),
+				Source: &rules.Checkpoint{
+					Epoch: 0,
+				},
+				Target: &rules.Checkpoint{
+					Epoch: 0,
+				},
+			},
+			res: rules.DENIED,
+		},
+		{
+			name:     "PostGenesisAttestation",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconAttestationData{
+				Domain: _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000"),
+				Source: &rules.Checkpoint{
+					Epoch: 0,
+				},
+				Target: &rules.Checkpoint{
+					Epoch: 1,
+				},
+			},
+			res: rules.APPROVED,
+		},
+		{
+			name:     "PostGenesisAttestationHigher",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconAttestationData{
+				Domain: _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000"),
+				Source: &rules.Checkpoint{
+					Epoch: 1,
+				},
+				Target: &rules.Checkpoint{
+					Epoch: 2,
+				},
+			},
+			res: rules.APPROVED,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := testRules.OnSignBeaconAttestation(ctx, test.metadata, test.req)
+			assert.Equal(t, test.res, res)
+		})
+	}
+}

--- a/rules/standard/signbeaconattestations_test.go
+++ b/rules/standard/signbeaconattestations_test.go
@@ -269,8 +269,8 @@ func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 	}{
 		{
 			// Two validators attest at epoch 0 from fresh state — both should be approved.
-			// Equal source/target at epoch 0 is the one accepted case (the guard at
-			// signbeaconattestations.go:142 explicitly allows source==target==0).
+			// Equal source/target at epoch 0 is the one accepted case (the
+			// "sourceEpoch != 0 || targetEpoch != 0" guard explicitly allows source==target==0).
 			name: "GenesisBatch",
 			metadata: []*rules.ReqMetadata{
 				{PubKey: pubKeyA},
@@ -352,6 +352,28 @@ func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 				},
 			},
 			res: []rules.Result{rules.APPROVED, rules.APPROVED},
+		},
+		{
+			// Mixed results in a single batch: A retries the current epoch (denied)
+			// while B advances (approved). Verifies per-validator independence.
+			name: "PostGenesisBatchMixed",
+			metadata: []*rules.ReqMetadata{
+				{PubKey: pubKeyA},
+				{PubKey: pubKeyB},
+			},
+			req: []*rules.SignBeaconAttestationData{
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 1},
+					Target: &rules.Checkpoint{Epoch: 2},
+				},
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 1},
+					Target: &rules.Checkpoint{Epoch: 3},
+				},
+			},
+			res: []rules.Result{rules.DENIED, rules.APPROVED},
 		},
 	}
 

--- a/rules/standard/signbeaconattestations_test.go
+++ b/rules/standard/signbeaconattestations_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/attestantio/dirk/rules"
 	standardrules "github.com/attestantio/dirk/rules/standard"
 	"github.com/attestantio/dirk/testing/logger"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -243,8 +244,7 @@ func TestSignBeaconAttestations(t *testing.T) {
 }
 
 // TestSignBeaconAttestationsEpochZero tests batch attestation signing at
-// epoch 0 (genesis), where no prior attestation state exists. Each step
-// builds on state left by the previous.
+// epoch 0 (genesis), where no prior attestation state exists.
 func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 	ctx := context.Background()
 	base, err := os.MkdirTemp("", "")
@@ -260,6 +260,7 @@ func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 
 	attestationDomain := _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000")
 
+	// Tests are sequential; each builds on state left by the previous.
 	tests := []struct {
 		name     string
 		metadata []*rules.ReqMetadata
@@ -268,6 +269,8 @@ func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 	}{
 		{
 			// Two validators attest at epoch 0 from fresh state — both should be approved.
+			// Equal source/target at epoch 0 is the one accepted case (the guard at
+			// signbeaconattestations.go:142 explicitly allows source==target==0).
 			name: "GenesisBatch",
 			metadata: []*rules.ReqMetadata{
 				{PubKey: pubKeyA},
@@ -355,7 +358,7 @@ func TestSignBeaconAttestationsEpochZero(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			res := testRules.OnSignBeaconAttestations(ctx, test.metadata, test.req)
-			require.Equal(t, test.res, res)
+			assert.Equal(t, test.res, res)
 		})
 	}
 }

--- a/rules/standard/signbeaconattestations_test.go
+++ b/rules/standard/signbeaconattestations_test.go
@@ -241,3 +241,121 @@ func TestSignBeaconAttestations(t *testing.T) {
 	cancelFunc()
 	time.Sleep(100 * time.Millisecond)
 }
+
+// TestSignBeaconAttestationsEpochZero tests batch attestation signing at
+// epoch 0 (genesis), where no prior attestation state exists. Each step
+// builds on state left by the previous.
+func TestSignBeaconAttestationsEpochZero(t *testing.T) {
+	ctx := context.Background()
+	base, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(base)
+	testRules, err := standardrules.New(ctx,
+		standardrules.WithStoragePath(base),
+	)
+	require.NoError(t, err)
+
+	pubKeyA := _byteStr(t, "a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+	pubKeyB := _byteStr(t, "b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+
+	attestationDomain := _byteStr(t, "0100000000000000000000000000000000000000000000000000000000000000")
+
+	tests := []struct {
+		name     string
+		metadata []*rules.ReqMetadata
+		req      []*rules.SignBeaconAttestationData
+		res      []rules.Result
+	}{
+		{
+			// Two validators attest at epoch 0 from fresh state — both should be approved.
+			name: "GenesisBatch",
+			metadata: []*rules.ReqMetadata{
+				{PubKey: pubKeyA},
+				{PubKey: pubKeyB},
+			},
+			req: []*rules.SignBeaconAttestationData{
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 0},
+				},
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 0},
+				},
+			},
+			res: []rules.Result{rules.APPROVED, rules.APPROVED},
+		},
+		{
+			// Same batch retried at epoch 0 — both should be denied (already signed).
+			name: "GenesisBatchRetry",
+			metadata: []*rules.ReqMetadata{
+				{PubKey: pubKeyA},
+				{PubKey: pubKeyB},
+			},
+			req: []*rules.SignBeaconAttestationData{
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 0},
+				},
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 0},
+				},
+			},
+			res: []rules.Result{rules.DENIED, rules.DENIED},
+		},
+		{
+			// Advance to epoch 1 — both should be approved.
+			name: "PostGenesisBatch",
+			metadata: []*rules.ReqMetadata{
+				{PubKey: pubKeyA},
+				{PubKey: pubKeyB},
+			},
+			req: []*rules.SignBeaconAttestationData{
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 1},
+				},
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 0},
+					Target: &rules.Checkpoint{Epoch: 1},
+				},
+			},
+			res: []rules.Result{rules.APPROVED, rules.APPROVED},
+		},
+		{
+			// Advance to epoch 2 — both should be approved.
+			name: "PostGenesisBatchHigher",
+			metadata: []*rules.ReqMetadata{
+				{PubKey: pubKeyA},
+				{PubKey: pubKeyB},
+			},
+			req: []*rules.SignBeaconAttestationData{
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 1},
+					Target: &rules.Checkpoint{Epoch: 2},
+				},
+				{
+					Domain: attestationDomain,
+					Source: &rules.Checkpoint{Epoch: 1},
+					Target: &rules.Checkpoint{Epoch: 2},
+				},
+			},
+			res: []rules.Result{rules.APPROVED, rules.APPROVED},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := testRules.OnSignBeaconAttestations(ctx, test.metadata, test.req)
+			require.Equal(t, test.res, res)
+		})
+	}
+}

--- a/rules/standard/signbeaconproposal_test.go
+++ b/rules/standard/signbeaconproposal_test.go
@@ -85,3 +85,59 @@ func TestSignBeaconProposal(t *testing.T) {
 		})
 	}
 }
+
+// TestSignBeaconProposalSlotZero tests slashing protection behavior
+// at slot 0 (genesis), where the sentinel value -1 transitions to 0.
+func TestSignBeaconProposalSlotZero(t *testing.T) {
+	ctx := context.Background()
+	base, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(base)
+	testRules, err := standardrules.New(ctx,
+		standardrules.WithStoragePath(base),
+	)
+	require.NoError(t, err)
+
+	// Tests are sequential; each builds on state left by the previous.
+	tests := []struct {
+		name     string
+		metadata *rules.ReqMetadata
+		req      *rules.SignBeaconProposalData
+		res      rules.Result
+	}{
+		{
+			name:     "GenesisSlotProposal",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconProposalData{
+				Domain: _byteStr(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+				Slot:   0,
+			},
+			res: rules.APPROVED,
+		},
+		{
+			name:     "GenesisSlotRetry",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconProposalData{
+				Domain: _byteStr(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+				Slot:   0,
+			},
+			res: rules.DENIED,
+		},
+		{
+			name:     "PostGenesisSlotProposal",
+			metadata: &rules.ReqMetadata{},
+			req: &rules.SignBeaconProposalData{
+				Domain: _byteStr(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+				Slot:   1,
+			},
+			res: rules.APPROVED,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := testRules.OnSignBeaconProposal(ctx, test.metadata, test.req)
+			assert.Equal(t, test.res, res)
+		})
+	}
+}

--- a/rules/standard/signbeaconproposal_test.go
+++ b/rules/standard/signbeaconproposal_test.go
@@ -87,7 +87,7 @@ func TestSignBeaconProposal(t *testing.T) {
 }
 
 // TestSignBeaconProposalSlotZero tests slashing protection behavior
-// at slot 0 (genesis), where the sentinel value -1 transitions to 0.
+// at slot 0 (genesis), where no prior proposal state exists.
 func TestSignBeaconProposalSlotZero(t *testing.T) {
 	ctx := context.Background()
 	base, err := os.MkdirTemp("", "")


### PR DESCRIPTION
## Problem

The rules layer's behavior at epoch 0 and slot 0 had no dedicated test coverage. During a devnet investigation, we confirmed the behavior is correct — Dirk's slashing protection correctly denies re-signing at `targetEpoch=0` and `slot=0` — but there were no tests documenting this as intentional.

## Solution

Add test cases covering single-path and batch-path attestation signing at epoch 0, as well as proposal signing at slot 0. These tests confirm that Dirk correctly enforces slashing protection at genesis boundaries and serve as regression tests for this behavior.