### PR TITLE
feat(rules): support CIDR ranges in admin-ips

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,8 +24,9 @@ server:
   # to `0.0.0.0` to listen on all network interfaces.
   listen-address: 127.0.0.1:13141
   rules:
-    # admin-ips is a list of IP addresses from which requests for voluntary exists will be accepted.
-    admin-ips: [ 1.2.3.4, 5.6.7.8 ]
+    # admin-ips is a list of IP addresses and/or CIDR ranges from which requests for voluntary exits
+    # will be accepted.
+    admin-ips: [ 1.2.3.4, 5.6.7.8, 10.0.0.0/8 ]
     # periodic-pruning will prune the rules storage if enabled every 1-2 days to keep the database size down.
     periodic-pruning: true
 certificates:

--- a/rules/standard/adminips.go
+++ b/rules/standard/adminips.go
@@ -1,0 +1,69 @@
+// Copyright © 2026 Attestant Limited.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package standard
+
+import (
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// parseAdminIPs turns the configured admin IP entries in to IP networks that can be
+// checked against an incoming request IP address.  Each entry may be a single IP
+// address, e.g. "1.2.3.4", or a CIDR range, e.g. "10.0.0.0/8"; a single IP address is
+// treated as a CIDR range covering that address alone.
+func parseAdminIPs(entries []string) ([]*net.IPNet, error) {
+	ipNets := make([]*net.IPNet, 0, len(entries))
+	for _, entry := range entries {
+		if strings.Contains(entry, "/") {
+			_, ipNet, err := net.ParseCIDR(entry)
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid admin IP CIDR range %q", entry)
+			}
+			ipNets = append(ipNets, ipNet)
+
+			continue
+		}
+
+		ip := net.ParseIP(entry)
+		if ip == nil {
+			return nil, errors.Errorf("invalid admin IP address %q", entry)
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			ipNets = append(ipNets, &net.IPNet{IP: ip4, Mask: net.CIDRMask(32, 32)})
+		} else {
+			ipNets = append(ipNets, &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)})
+		}
+	}
+
+	return ipNets, nil
+}
+
+// adminIPAllowed returns true if the given request IP address falls within any of the
+// configured admin IP networks.
+func adminIPAllowed(adminIPNets []*net.IPNet, requestIP string) bool {
+	ip := net.ParseIP(requestIP)
+	if ip == nil {
+		return false
+	}
+
+	for _, ipNet := range adminIPNets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/rules/standard/parameters.go
+++ b/rules/standard/parameters.go
@@ -51,7 +51,8 @@ func WithStoragePath(storagePath string) Parameter {
 	})
 }
 
-// WithAdminIPs sets the administration IP addreses for the module.
+// WithAdminIPs sets the administration IP addresses for the module.  Entries may be
+// individual IP addresses or CIDR ranges.
 func WithAdminIPs(adminIPs []string) Parameter {
 	return parameterFunc(func(p *parameters) {
 		p.adminIPs = adminIPs

--- a/rules/standard/rules_test.go
+++ b/rules/standard/rules_test.go
@@ -57,6 +57,26 @@ func TestRules(t *testing.T) {
 			logLevel: zerolog.Disabled,
 			path:     os.TempDir(),
 		},
+		{
+			name:     "AdminIPsCIDRGood",
+			logLevel: zerolog.Disabled,
+			path:     os.TempDir(),
+			validIPs: []string{"1.2.3.4", "10.0.0.0/8", "::1/128"},
+		},
+		{
+			name:     "AdminIPsBad",
+			logLevel: zerolog.Disabled,
+			path:     os.TempDir(),
+			validIPs: []string{"not-an-ip"},
+			err:      []string{`problem with admin IPs: invalid admin IP address "not-an-ip"`},
+		},
+		{
+			name:     "AdminIPsBadCIDR",
+			logLevel: zerolog.Disabled,
+			path:     os.TempDir(),
+			validIPs: []string{"10.0.0.0/33"},
+			err:      []string{`problem with admin IPs: invalid admin IP CIDR range "10.0.0.0/33"`},
+		},
 	}
 
 	for _, test := range tests {

--- a/rules/standard/service.go
+++ b/rules/standard/service.go
@@ -15,6 +15,7 @@ package standard
 
 import (
 	"context"
+	"net"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -23,9 +24,9 @@ import (
 
 // Service is the structure that keeps track of rules.
 type Service struct {
-	log      zerolog.Logger
-	store    *Store
-	adminIPs []string
+	log         zerolog.Logger
+	store       *Store
+	adminIPNets []*net.IPNet
 }
 
 // New creates new rules.
@@ -41,15 +42,20 @@ func New(ctx context.Context, params ...Parameter) (*Service, error) {
 		log = log.Level(parameters.logLevel)
 	}
 
+	adminIPNets, err := parseAdminIPs(parameters.adminIPs)
+	if err != nil {
+		return nil, errors.Wrap(err, "problem with admin IPs")
+	}
+
 	store, err := NewStore(ctx, parameters.storagePath, parameters.periodicPruning, log)
 	if err != nil {
 		return nil, err
 	}
 
 	s := &Service{
-		log:      log,
-		store:    store,
-		adminIPs: parameters.adminIPs,
+		log:         log,
+		store:       store,
+		adminIPNets: adminIPNets,
 	}
 
 	// Close the store when the context is cancelled.

--- a/rules/standard/sign.go
+++ b/rules/standard/sign.go
@@ -48,14 +48,7 @@ func (s *Service) OnSign(ctx context.Context, metadata *rules.ReqMetadata, req *
 			log.Warn().Msg("Not signing voluntary exit request from unknown source")
 			return rules.DENIED
 		}
-		validIP := false
-		for i := range s.adminIPs {
-			if metadata.IP == s.adminIPs[i] {
-				validIP = true
-				break
-			}
-		}
-		if !validIP {
+		if !adminIPAllowed(s.adminIPNets, metadata.IP) {
 			log.Warn().Str("request_ip", metadata.IP).Msg("Not signing voluntary exit request from unapproved IP address")
 			return rules.DENIED
 		}

--- a/rules/standard/sign_test.go
+++ b/rules/standard/sign_test.go
@@ -40,7 +40,7 @@ func TestSign(t *testing.T) {
 
 	testRules, err := standardrules.New(ctx,
 		standardrules.WithStoragePath(base),
-		standardrules.WithAdminIPs([]string{"1.2.3.4", "5.6.7.8"}),
+		standardrules.WithAdminIPs([]string{"1.2.3.4", "5.6.7.8", "10.0.0.0/8"}),
 	)
 	require.NoError(t, err)
 
@@ -115,6 +115,28 @@ func TestSign(t *testing.T) {
 				Domain: _byteStr(t, "0400000000000000000000000000000000000000000000000000000000000000"),
 			},
 			res: rules.APPROVED,
+		},
+		{
+			name: "GoodVEIPCIDR",
+			metadata: &rules.ReqMetadata{
+				IP: "10.1.2.3",
+			},
+			req: &rules.SignData{
+				Data:   _byteStr(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+				Domain: _byteStr(t, "0400000000000000000000000000000000000000000000000000000000000000"),
+			},
+			res: rules.APPROVED,
+		},
+		{
+			name: "OutsideVEIPCIDR",
+			metadata: &rules.ReqMetadata{
+				IP: "11.1.2.3",
+			},
+			req: &rules.SignData{
+				Data:   _byteStr(t, "0000000000000000000000000000000000000000000000000000000000000000"),
+				Domain: _byteStr(t, "0400000000000000000000000000000000000000000000000000000000000000"),
+			},
+			res: rules.DENIED,
 		},
 	}
 


### PR DESCRIPTION
Now admin-ips entries may now be individual IP addresses or CIDR ranges; a plain IP is treated as a CIDR covering that address alone. Invalid entries are now rejected at startup instead of silently never matching.